### PR TITLE
docs: shorten README tagline and use "X+" version format

### DIFF
--- a/NUGET-README.md
+++ b/NUGET-README.md
@@ -12,8 +12,9 @@ BM25 index creation must be defined using raw SQL. See the [EF Core documentatio
 
 | Component  | Supported                     |
 | ---------- | ----------------------------- |
-| .NET       | 8, 9, 10                      |
-| ParadeDB   | 0.23.0+                       |
+| .NET       | 8+                            |
+| EF Core    | 8+                            |
+| ParadeDB   | 0.22.0+                       |
 | PostgreSQL | 15+ (with ParadeDB extension) |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@
 
 ## ParadeDB for Entity Framework Core
 
-The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com), built on top of [Npgsql.EntityFrameworkCore.PostgreSQL](https://www.npgsql.org/efcore/index.html), exposing ParadeDB search functions through the `EF.Functions` API for LINQ-based full-text search queries. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#efcore) to begin.
+The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com), including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#efcore) to begin.
 
 ## Requirements & Compatibility
 
 | Component  | Supported                     |
 | ---------- | ----------------------------- |
-| .NET       | 8, 9, 10                      |
-| EF Core    | 8, 9, 10                      |
-| ParadeDB   | 0.23.0+                       |
+| .NET       | 8+                            |
+| EF Core    | 8+                            |
+| ParadeDB   | 0.22.0+                       |
 | PostgreSQL | 15+ (with ParadeDB extension) |
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@
 
 ---
 
+> [!WARNING]
+> `efcore-paradedb` is a work in progress and is **not yet ready for public consumption**. APIs, packaging, and behavior may change without notice while we stabilize the integration. Pin to an exact version if you experiment with it, and watch the repository for release announcements.
+
 ## ParadeDB for Entity Framework Core
 
 The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com), including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#efcore) to begin.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 
 ---
 
-> [!WARNING]
-> `efcore-paradedb` is a work in progress and is **not yet ready for public consumption**. APIs, packaging, and behavior may change without notice while we stabilize the integration. Pin to an exact version if you experiment with it, and watch the repository for release announcements.
+> [!NOTE]
+> `efcore-paradedb` is a work in progress and is not yet recommended for production use. APIs may evolve as we stabilize the integration — pin to an exact version if you're trying it out.
 
 ## ParadeDB for Entity Framework Core
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,7 +45,7 @@ GitHub release do not already exist.
 The canonical support matrix lives in `README.md` under
 **Requirements & Compatibility** and should be kept up to date.
 
-Today, the maintained minimum ParadeDB version is `0.23.0`. Update the README
+Today, the maintained minimum ParadeDB version is `0.22.0`. Update the README
 matrix, CI image tags, and any version-gated examples in the same PR whenever
 that floor changes.
 
@@ -54,7 +54,7 @@ that floor changes.
 - .NET: 8, 9, 10
 - Entity Framework Core: via Npgsql.EntityFrameworkCore.PostgreSQL
 - PostgreSQL: 15+ with the ParadeDB extension
-- ParadeDB: 0.23.0+
+- ParadeDB: 0.22.0+
 
 ## Pre-Release Checklist
 


### PR DESCRIPTION
## Summary

Align the README tagline and Requirements & Compatibility table with `django-paradedb` / `sqlalchemy-paradedb` / `rails-paradedb` so the ORM family stays consistent.

### Tagline

Was:

> The official Entity Framework Core integration for ParadeDB, built on top of Npgsql.EntityFrameworkCore.PostgreSQL, exposing ParadeDB search functions through the EF.Functions API for LINQ-based full-text search queries. Follow the getting started guide to begin.

Now:

> The official Entity Framework Core integration for ParadeDB, including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. Follow the getting started guide to begin.

Mirrors the django phrasing; the Npgsql / `EF.Functions` / LINQ details belong on docs.paradedb.com, not the front-page README.

### Requirements & Compatibility

Switch the version columns to the same `X+` shape Django uses, instead of enumerating every supported major:

| Component  | Was      | Now      |
| ---------- | -------- | -------- |
| .NET       | 8, 9, 10 | 8+       |
| EF Core    | 8, 9, 10 | 8+       |
| ParadeDB   | 0.23.0+  | 0.22.0+  |
| PostgreSQL | unchanged           ||

`NUGET-README.md` table updated the same way (and gains the missing EF Core row).

### ParadeDB minimum: 0.23.0 → 0.22.0

Matches the documented minimum used by django-paradedb, sqlalchemy-paradedb, and rails-paradedb. Updated in:

- `README.md` (Requirements & Compatibility table)
- `NUGET-README.md` (same table)
- `RELEASE.md` ("maintained minimum ParadeDB version" line and the compatibility-targets list)

### Intentionally not changed

- `scripts/run_paradedb.sh` keeps `PARADEDB_VERSION=0.23.0` — that's a pinned default for the local dev container.
- CI service image keeps `paradedb/paradedb:0.23.0-pg18` — integration tests pin a specific version for reproducibility. The *documented minimum supported version* is a separate concern from *what CI happens to test against*. If we want CI to also cover the 0.22.0 floor, that's a follow-up (add another matrix entry in `ci.yml`).

## Test plan

- [x] `lint-markdown` workflow passes
- [x] Render preview on GitHub: tagline reads cleanly, table renders correctly