### PR TITLE
feat: Add index management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Testing
+
+Use `dotnet test -f net10.0` when verifying your changes. Do not run `dotnet build`.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ If you need commercial support, please [contact the ParadeDB team](mailto:sales@
 
 ## Acknowledgments
 
-We would like to thank the following members of the Entity Framework Core community for the initial implementation of this project:
+We would like to thank the following members of the Entity Framework Core community:
 
-- [Nandor Krizbai](https://github.com/nandor23) - .NET developer
+- [Nandor Krizbai](https://github.com/nandor23) - for the initial implementation of this project
+- [Daniel Oliveira](https://github.com/daniel3303) - for implementing [ParadeDbEntityFrameworkCore](https://github.com/daniel3303/ParadeDbEntityFrameworkCore) which inspired our indexing implementation
 
 ## License
 

--- a/src/Extensions/ParadeDbIndexBuilderExtensions.cs
+++ b/src/Extensions/ParadeDbIndexBuilderExtensions.cs
@@ -131,6 +131,13 @@ public sealed class Bm25IndexBuilder<TEntity>
         return this;
     }
 
+    public Bm25IndexBuilder<TEntity> IsCreatedConcurrently(bool createdConcurrently = true)
+    {
+        _indexBuilder.IsCreatedConcurrently(createdConcurrently);
+
+        return this;
+    }
+
     private void AddField(string field, string kind, Tokenizer? tokenizer, string? @alias)
     {
         var properties = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldProperties);

--- a/src/Extensions/ParadeDbIndexBuilderExtensions.cs
+++ b/src/Extensions/ParadeDbIndexBuilderExtensions.cs
@@ -26,6 +26,7 @@ public static class ParadeDbIndexBuilderExtensions
         // so that it can be rendered appropriately
         indexBuilder.HasAnnotation(ParadeDbAnnotationNames.Bm25FieldKinds, new[] { "property" });
         indexBuilder.HasAnnotation(ParadeDbAnnotationNames.Bm25FieldTokenizers, new[] { "" });
+        indexBuilder.HasAnnotation(ParadeDbAnnotationNames.Bm25FieldAliases, new[] { "" });
 
         return new Bm25IndexBuilder<TEntity>(indexBuilder);
     }
@@ -44,6 +45,8 @@ public static class ParadeDbIndexBuilderExtensions
     }
 }
 
+public record FieldAlias(string name) { }
+
 // We use a custom index builder class instead of IndexBuilder directly to make it clear that not all
 // normal index creation operations are supported here (e.g. `IsUnique`)
 public sealed class Bm25IndexBuilder<TEntity>
@@ -57,22 +60,66 @@ public sealed class Bm25IndexBuilder<TEntity>
     }
 
     public Bm25IndexBuilder<TEntity> HasField<TProperty>(
-        Expression<Func<TEntity, TProperty>> propertyExpression,
-        Tokenizer? tokenizer = null
+        Expression<Func<TEntity, TProperty>> propertyExpression
     )
     {
         AddField(
             ParadeDbIndexBuilderExtensions.GetPropertyName(propertyExpression),
             "property",
-            tokenizer
+            null,
+            null
         );
 
         return this;
     }
 
-    public Bm25IndexBuilder<TEntity> HasField(string sql, Tokenizer? tokenizer = null)
+    public Bm25IndexBuilder<TEntity> HasField(string sql)
     {
-        AddField(sql, "sql", tokenizer);
+        AddField(sql, "sql", null, null);
+
+        return this;
+    }
+
+    public Bm25IndexBuilder<TEntity> HasField<TProperty>(
+        Expression<Func<TEntity, TProperty>> propertyExpression,
+        Tokenizer tokenizer
+    )
+    {
+        AddField(
+            ParadeDbIndexBuilderExtensions.GetPropertyName(propertyExpression),
+            "property",
+            tokenizer,
+            null
+        );
+
+        return this;
+    }
+
+    public Bm25IndexBuilder<TEntity> HasField(string sql, Tokenizer tokenizer)
+    {
+        AddField(sql, "sql", tokenizer, null);
+
+        return this;
+    }
+
+    public Bm25IndexBuilder<TEntity> HasField<TProperty>(
+        Expression<Func<TEntity, TProperty>> propertyExpression,
+        FieldAlias @alias
+    )
+    {
+        AddField(
+            ParadeDbIndexBuilderExtensions.GetPropertyName(propertyExpression),
+            "property",
+            null,
+            @alias.name
+        );
+
+        return this;
+    }
+
+    public Bm25IndexBuilder<TEntity> HasField(string sql, FieldAlias @alias)
+    {
+        AddField(sql, "sql", null, @alias.name);
 
         return this;
     }
@@ -84,11 +131,12 @@ public sealed class Bm25IndexBuilder<TEntity>
         return this;
     }
 
-    private void AddField(string field, string kind, Tokenizer? tokenizer)
+    private void AddField(string field, string kind, Tokenizer? tokenizer, string? @alias)
     {
         var properties = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldProperties);
         var kinds = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldKinds);
         var tokenizers = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldTokenizers);
+        var aliases = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldAliases);
 
         _indexBuilder.HasAnnotation(
             ParadeDbAnnotationNames.Bm25FieldProperties,
@@ -101,6 +149,11 @@ public sealed class Bm25IndexBuilder<TEntity>
         _indexBuilder.HasAnnotation(
             ParadeDbAnnotationNames.Bm25FieldTokenizers,
             tokenizers.Append(tokenizer?.ToString() ?? "").ToArray()
+        );
+
+        _indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.Bm25FieldAliases,
+            aliases.Append(@alias is null ? "" : @alias.Replace("'", "''")).ToArray()
         );
     }
 

--- a/src/Extensions/ParadeDbIndexBuilderExtensions.cs
+++ b/src/Extensions/ParadeDbIndexBuilderExtensions.cs
@@ -138,6 +138,16 @@ public sealed class Bm25IndexBuilder<TEntity>
         return this;
     }
 
+    public Bm25IndexBuilder<TEntity> HasSearchTokenizer(Tokenizer tokenizer)
+    {
+        _indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.Bm25SearchTokenizer,
+            tokenizer.ToSearchString()
+        );
+
+        return this;
+    }
+
     private void AddField(string field, string kind, Tokenizer? tokenizer, string? @alias)
     {
         var properties = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldProperties);

--- a/src/Extensions/ParadeDbIndexBuilderExtensions.cs
+++ b/src/Extensions/ParadeDbIndexBuilderExtensions.cs
@@ -73,13 +73,6 @@ public sealed class Bm25IndexBuilder<TEntity>
         return this;
     }
 
-    public Bm25IndexBuilder<TEntity> HasField(string sql)
-    {
-        AddField(sql, "sql", null, null);
-
-        return this;
-    }
-
     public Bm25IndexBuilder<TEntity> HasField<TProperty>(
         Expression<Func<TEntity, TProperty>> propertyExpression,
         Tokenizer tokenizer

--- a/src/Extensions/ParadeDbIndexBuilderExtensions.cs
+++ b/src/Extensions/ParadeDbIndexBuilderExtensions.cs
@@ -1,0 +1,109 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ParadeDB.EntityFrameworkCore.Internal.Metadata;
+
+namespace ParadeDB.EntityFrameworkCore.Extensions;
+
+public static class ParadeDbIndexBuilderExtensions
+{
+    public static Bm25IndexBuilder<TEntity> HasBm25Index<TEntity>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        string name,
+        Expression<Func<TEntity, object?>> keyExpression
+    )
+        where TEntity : class
+    {
+        var keyProperty = GetPropertyName(keyExpression);
+        var indexBuilder = entityTypeBuilder.HasIndex(keyExpression).HasDatabaseName(name);
+
+        indexBuilder.HasAnnotation(ParadeDbAnnotationNames.Bm25KeyProperty, keyProperty);
+        indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.Bm25FieldProperties,
+            new[] { keyProperty }
+        );
+        // BM25FieldKinds is used to track if each index field is an EF Core property or a SQL expression
+        // so that it can be rendered appropriately
+        indexBuilder.HasAnnotation(ParadeDbAnnotationNames.Bm25FieldKinds, new[] { "property" });
+        indexBuilder.HasAnnotation(ParadeDbAnnotationNames.Bm25FieldTokenizers, new[] { "" });
+
+        return new Bm25IndexBuilder<TEntity>(indexBuilder);
+    }
+
+    internal static string GetPropertyName<TEntity, TProperty>(
+        Expression<Func<TEntity, TProperty>> propertyExpression
+    )
+    {
+        var body = propertyExpression.Body is UnaryExpression unary
+            ? unary.Operand
+            : propertyExpression.Body;
+
+        return body is MemberExpression member
+            ? member.Member.Name
+            : throw new ArgumentException("The BM25 key expression must be a property access.");
+    }
+}
+
+// We use a custom index builder class instead of IndexBuilder directly to make it clear that not all
+// normal index creation operations are supported here (e.g. `IsUnique`)
+public sealed class Bm25IndexBuilder<TEntity>
+    where TEntity : class
+{
+    private readonly IndexBuilder<TEntity> _indexBuilder;
+
+    internal Bm25IndexBuilder(IndexBuilder<TEntity> indexBuilder)
+    {
+        _indexBuilder = indexBuilder;
+    }
+
+    public Bm25IndexBuilder<TEntity> HasField<TProperty>(
+        Expression<Func<TEntity, TProperty>> propertyExpression,
+        Tokenizer? tokenizer = null
+    )
+    {
+        AddField(
+            ParadeDbIndexBuilderExtensions.GetPropertyName(propertyExpression),
+            "property",
+            tokenizer
+        );
+
+        return this;
+    }
+
+    public Bm25IndexBuilder<TEntity> HasField(string sql, Tokenizer? tokenizer = null)
+    {
+        AddField(sql, "sql", tokenizer);
+
+        return this;
+    }
+
+    public Bm25IndexBuilder<TEntity> HasFilter(string? sql)
+    {
+        _indexBuilder.HasFilter(sql);
+
+        return this;
+    }
+
+    private void AddField(string field, string kind, Tokenizer? tokenizer)
+    {
+        var properties = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldProperties);
+        var kinds = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldKinds);
+        var tokenizers = GetAnnotation(ParadeDbAnnotationNames.Bm25FieldTokenizers);
+
+        _indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.Bm25FieldProperties,
+            properties.Append(field).ToArray()
+        );
+        _indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.Bm25FieldKinds,
+            kinds.Append(kind).ToArray()
+        );
+        _indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.Bm25FieldTokenizers,
+            tokenizers.Append(tokenizer?.ToString() ?? "").ToArray()
+        );
+    }
+
+    private string[] GetAnnotation(string name) =>
+        (string[]?)_indexBuilder.Metadata.FindAnnotation(name)?.Value ?? [];
+}

--- a/src/Internal/Metadata/ParadeDbAnnotationNames.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationNames.cs
@@ -7,6 +7,7 @@ internal static class ParadeDbAnnotationNames
     public const string Bm25FieldKinds = "ParadeDB:Bm25FieldKinds";
     public const string Bm25FieldTokenizers = "ParadeDB:Bm25FieldTokenizers";
     public const string Bm25FieldAliases = "ParadeDB:Bm25FieldAliases";
+    public const string Bm25SearchTokenizer = "ParadeDB:Bm25SearchTokenizer";
     public const string Bm25KeyField = "ParadeDB:Bm25KeyField";
     public const string Bm25Fields = "ParadeDB:Bm25Fields";
 }

--- a/src/Internal/Metadata/ParadeDbAnnotationNames.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationNames.cs
@@ -1,0 +1,11 @@
+namespace ParadeDB.EntityFrameworkCore.Internal.Metadata;
+
+internal static class ParadeDbAnnotationNames
+{
+    public const string Bm25KeyProperty = "ParadeDB:Bm25KeyProperty";
+    public const string Bm25FieldProperties = "ParadeDB:Bm25FieldProperties";
+    public const string Bm25FieldKinds = "ParadeDB:Bm25FieldKinds";
+    public const string Bm25FieldTokenizers = "ParadeDB:Bm25FieldTokenizers";
+    public const string Bm25KeyField = "ParadeDB:Bm25KeyField";
+    public const string Bm25Fields = "ParadeDB:Bm25Fields";
+}

--- a/src/Internal/Metadata/ParadeDbAnnotationNames.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationNames.cs
@@ -6,6 +6,7 @@ internal static class ParadeDbAnnotationNames
     public const string Bm25FieldProperties = "ParadeDB:Bm25FieldProperties";
     public const string Bm25FieldKinds = "ParadeDB:Bm25FieldKinds";
     public const string Bm25FieldTokenizers = "ParadeDB:Bm25FieldTokenizers";
+    public const string Bm25FieldAliases = "ParadeDB:Bm25FieldAliases";
     public const string Bm25KeyField = "ParadeDB:Bm25KeyField";
     public const string Bm25Fields = "ParadeDB:Bm25Fields";
 }

--- a/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
@@ -43,14 +43,18 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
             (string[]?)
                 mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldTokenizers)?.Value
             ?? [];
+        var fieldAliases =
+            (string[]?)mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldAliases)?.Value
+            ?? [];
 
         if (
             fieldProperties.Length != fieldKinds.Length
             || fieldProperties.Length != fieldTokenizers.Length
+            || fieldProperties.Length != fieldAliases.Length
         )
         {
             throw new InvalidOperationException(
-                "A BM25 index must have one kind and tokenizer entry for each field."
+                "A BM25 index must have one kind, tokenizer, and alias entry for each field."
             );
         }
 
@@ -60,6 +64,7 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
             ParadeDbAnnotationNames.Bm25KeyField,
             GetColumnName(mappedIndex.DeclaringEntityType, keyPropertyName, storeObject)
         );
+
         yield return new Annotation(
             ParadeDbAnnotationNames.Bm25Fields,
             fieldProperties
@@ -70,7 +75,8 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
                             field,
                             fieldKinds[i],
                             storeObject,
-                            string.IsNullOrEmpty(fieldTokenizers[i]) ? null : fieldTokenizers[i]
+                            string.IsNullOrEmpty(fieldTokenizers[i]) ? null : fieldTokenizers[i],
+                            string.IsNullOrEmpty(fieldAliases[i]) ? null : fieldAliases[i]
                         )
                 )
                 .ToArray()
@@ -82,7 +88,8 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
         string field,
         string kind,
         StoreObjectIdentifier storeObject,
-        string? tokenizer
+        string? tokenizer,
+        string? @alias
     )
     {
         var sql =
@@ -92,12 +99,26 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
                 $"The BM25 field kind '{kind}' is not supported."
             );
 
-        if (tokenizer is null)
+        if (tokenizer is null && @alias is null)
         {
             return sql;
         }
 
-        return kind == "property" ? $"({sql}::{tokenizer})" : $"(({sql})::{tokenizer})";
+        if (tokenizer is not null && @alias is not null)
+        {
+            throw new InvalidOperationException(
+                $"A field may not have a tokenizer and alias at the same time {tokenizer}, {@alias}"
+            );
+        }
+
+        if (tokenizer is not null)
+        {
+            return kind == "property" ? $"({sql}::{tokenizer})" : $"(({sql})::{tokenizer})";
+        }
+
+        return kind == "property"
+            ? $"({sql}::pdb.alias('{@alias}'))"
+            : $"(({sql})::pdb.alias('{@alias}'))";
     }
 
     private static string GetColumnName(

--- a/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
@@ -1,0 +1,120 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+
+namespace ParadeDB.EntityFrameworkCore.Internal.Metadata;
+
+// NpgsqlAnnotationProvider is not part of the public API they explicitly note that it
+// is not subject to the same compatibility standards as the public API. So we may have to
+// rework things here to support new releases. I don't know that there is a way for us to
+// implement the indexing functionality in a way that only relies on the public API.
+internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
+{
+    public ParadeDbAnnotationProvider(RelationalAnnotationProviderDependencies dependencies)
+        : base(dependencies) { }
+
+    public override IEnumerable<IAnnotation> For(ITableIndex index, bool designTime)
+    {
+        foreach (var annotation in base.For(index, designTime))
+        {
+            yield return annotation;
+        }
+
+        var mappedIndex = index.MappedIndexes.FirstOrDefault(i =>
+            i.FindAnnotation(ParadeDbAnnotationNames.Bm25KeyProperty)?.Value is string
+        );
+        if (
+            mappedIndex?.FindAnnotation(ParadeDbAnnotationNames.Bm25KeyProperty)?.Value
+            is not string keyPropertyName
+        )
+        {
+            yield break;
+        }
+
+        var fieldProperties =
+            (string[]?)
+                mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldProperties)?.Value
+            ?? [];
+        var fieldKinds =
+            (string[]?)mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldKinds)?.Value
+            ?? [];
+        var fieldTokenizers =
+            (string[]?)
+                mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldTokenizers)?.Value
+            ?? [];
+
+        if (
+            fieldProperties.Length != fieldKinds.Length
+            || fieldProperties.Length != fieldTokenizers.Length
+        )
+        {
+            throw new InvalidOperationException(
+                "A BM25 index must have one kind and tokenizer entry for each field."
+            );
+        }
+
+        var storeObject = StoreObjectIdentifier.Table(index.Table.Name, index.Table.Schema);
+
+        yield return new Annotation(
+            ParadeDbAnnotationNames.Bm25KeyField,
+            GetColumnName(mappedIndex.DeclaringEntityType, keyPropertyName, storeObject)
+        );
+        yield return new Annotation(
+            ParadeDbAnnotationNames.Bm25Fields,
+            fieldProperties
+                .Select(
+                    (field, i) =>
+                        RenderField(
+                            mappedIndex.DeclaringEntityType,
+                            field,
+                            fieldKinds[i],
+                            storeObject,
+                            string.IsNullOrEmpty(fieldTokenizers[i]) ? null : fieldTokenizers[i]
+                        )
+                )
+                .ToArray()
+        );
+    }
+
+    private static string RenderField(
+        IReadOnlyEntityType entityType,
+        string field,
+        string kind,
+        StoreObjectIdentifier storeObject,
+        string? tokenizer
+    )
+    {
+        var sql =
+            kind == "property" ? GetColumnName(entityType, field, storeObject)
+            : kind == "sql" ? field
+            : throw new InvalidOperationException(
+                $"The BM25 field kind '{kind}' is not supported."
+            );
+
+        if (tokenizer is null)
+        {
+            return sql;
+        }
+
+        return kind == "property" ? $"({sql}::{tokenizer})" : $"(({sql})::{tokenizer})";
+    }
+
+    private static string GetColumnName(
+        IReadOnlyEntityType entityType,
+        string propertyName,
+        StoreObjectIdentifier storeObject
+    )
+    {
+        var property =
+            entityType.FindProperty(propertyName)
+            ?? throw new InvalidOperationException(
+                $"The BM25 field '{propertyName}' was not found."
+            );
+
+        return property.GetColumnName(storeObject)
+            ?? throw new InvalidOperationException(
+                $"The BM25 field '{propertyName}' is not mapped to a column."
+            );
+    }
+}

--- a/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
@@ -32,20 +32,14 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
             yield break;
         }
 
-        var fieldProperties =
-            (string[]?)
-                mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldProperties)?.Value
-            ?? [];
-        var fieldKinds =
-            (string[]?)mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldKinds)?.Value
-            ?? [];
-        var fieldTokenizers =
-            (string[]?)
-                mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldTokenizers)?.Value
-            ?? [];
-        var fieldAliases =
-            (string[]?)mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldAliases)?.Value
-            ?? [];
+        var fieldProperties = (string[])
+            mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldProperties)!.Value!;
+        var fieldKinds = (string[])
+            mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldKinds)!.Value!;
+        var fieldTokenizers = (string[])
+            mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldTokenizers)!.Value!;
+        var fieldAliases = (string[])
+            mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25FieldAliases)!.Value!;
 
         if (
             fieldProperties.Length != fieldKinds.Length
@@ -62,7 +56,9 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
 
         yield return new Annotation(
             ParadeDbAnnotationNames.Bm25KeyField,
-            GetColumnName(mappedIndex.DeclaringEntityType, keyPropertyName, storeObject)
+            mappedIndex
+                .DeclaringEntityType.FindProperty(keyPropertyName)!
+                .GetColumnName(storeObject)!
         );
 
         yield return new Annotation(
@@ -103,12 +99,12 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
         string? @alias
     )
     {
-        var sql =
-            kind == "property" ? GetColumnName(entityType, field, storeObject)
-            : kind == "sql" ? field
-            : throw new InvalidOperationException(
-                $"The BM25 field kind '{kind}' is not supported."
-            );
+        var sql = kind switch
+        {
+            "property" => entityType.FindProperty(field)!.GetColumnName(storeObject)!,
+            "sql" => field,
+            _ => throw new InvalidOperationException($"Unknown field kind '{kind}'"),
+        };
 
         if (tokenizer is null && @alias is null)
         {
@@ -138,15 +134,6 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
         StoreObjectIdentifier storeObject
     )
     {
-        var property =
-            entityType.FindProperty(propertyName)
-            ?? throw new InvalidOperationException(
-                $"The BM25 field '{propertyName}' was not found."
-            );
-
-        return property.GetColumnName(storeObject)
-            ?? throw new InvalidOperationException(
-                $"The BM25 field '{propertyName}' is not mapped to a column."
-            );
+        return entityType.FindProperty(propertyName)!.GetColumnName(storeObject)!;
     }
 }

--- a/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
@@ -81,6 +81,17 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
                 )
                 .ToArray()
         );
+
+        if (
+            mappedIndex.FindAnnotation(ParadeDbAnnotationNames.Bm25SearchTokenizer)?.Value
+            is string searchTokenizer
+        )
+        {
+            yield return new Annotation(
+                ParadeDbAnnotationNames.Bm25SearchTokenizer,
+                searchTokenizer
+            );
+        }
     }
 
     private static string RenderField(

--- a/src/Internal/Migrations/ParadeDbMigrationsSqlGenerator.cs
+++ b/src/Internal/Migrations/ParadeDbMigrationsSqlGenerator.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Migrations;
+using ParadeDB.EntityFrameworkCore.Internal.Metadata;
+
+namespace ParadeDB.EntityFrameworkCore.Internal.Migrations;
+
+internal sealed class ParadeDbMigrationsSqlGenerator : NpgsqlMigrationsSqlGenerator
+{
+    public ParadeDbMigrationsSqlGenerator(
+        MigrationsSqlGeneratorDependencies dependencies,
+        INpgsqlSingletonOptions npgsqlSingletonOptions
+    )
+        : base(dependencies, npgsqlSingletonOptions) { }
+
+    protected override void Generate(
+        CreateIndexOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder,
+        bool terminate = true
+    )
+    {
+        if (
+            operation.FindAnnotation(ParadeDbAnnotationNames.Bm25Fields)?.Value
+                is not string[] fields
+            || operation.FindAnnotation(ParadeDbAnnotationNames.Bm25KeyField)?.Value
+                is not string keyField
+        )
+        {
+            base.Generate(operation, model, builder, terminate);
+            return;
+        }
+
+        var helper = Dependencies.SqlGenerationHelper;
+
+        builder
+            .Append("CREATE INDEX ")
+            .Append(helper.DelimitIdentifier(operation.Name))
+            .Append(" ON ")
+            .Append(helper.DelimitIdentifier(operation.Table, operation.Schema))
+            .Append(" USING bm25 (")
+            .Append(string.Join(", ", fields))
+            .Append(") WITH (key_field = ")
+            .Append(
+                Dependencies
+                    .TypeMappingSource.FindMapping(typeof(string))!
+                    .GenerateSqlLiteral(keyField)
+            )
+            .Append(")");
+
+        if (operation.Filter is not null)
+        {
+            builder.Append(" WHERE ").Append(operation.Filter);
+        }
+
+        if (terminate)
+        {
+            builder.AppendLine(helper.StatementTerminator).EndCommand();
+        }
+    }
+}

--- a/src/Internal/Migrations/ParadeDbMigrationsSqlGenerator.cs
+++ b/src/Internal/Migrations/ParadeDbMigrationsSqlGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Migrations;
 using ParadeDB.EntityFrameworkCore.Internal.Metadata;
 
@@ -34,9 +35,12 @@ internal sealed class ParadeDbMigrationsSqlGenerator : NpgsqlMigrationsSqlGenera
         }
 
         var helper = Dependencies.SqlGenerationHelper;
+        var createdConcurrently =
+            operation.FindAnnotation(NpgsqlAnnotationNames.CreatedConcurrently)?.Value is true;
 
         builder
             .Append("CREATE INDEX ")
+            .Append(createdConcurrently ? "CONCURRENTLY " : "")
             .Append(helper.DelimitIdentifier(operation.Name))
             .Append(" ON ")
             .Append(helper.DelimitIdentifier(operation.Table, operation.Schema))
@@ -57,7 +61,9 @@ internal sealed class ParadeDbMigrationsSqlGenerator : NpgsqlMigrationsSqlGenera
 
         if (terminate)
         {
-            builder.AppendLine(helper.StatementTerminator).EndCommand();
+            builder
+                .AppendLine(helper.StatementTerminator)
+                .EndCommand(suppressTransaction: createdConcurrently);
         }
     }
 }

--- a/src/Internal/Migrations/ParadeDbMigrationsSqlGenerator.cs
+++ b/src/Internal/Migrations/ParadeDbMigrationsSqlGenerator.cs
@@ -35,8 +35,11 @@ internal sealed class ParadeDbMigrationsSqlGenerator : NpgsqlMigrationsSqlGenera
         }
 
         var helper = Dependencies.SqlGenerationHelper;
+        var stringMapping = Dependencies.TypeMappingSource.FindMapping(typeof(string))!;
         var createdConcurrently =
             operation.FindAnnotation(NpgsqlAnnotationNames.CreatedConcurrently)?.Value is true;
+        var searchTokenizer =
+            operation.FindAnnotation(ParadeDbAnnotationNames.Bm25SearchTokenizer)?.Value as string;
 
         builder
             .Append("CREATE INDEX ")
@@ -47,12 +50,16 @@ internal sealed class ParadeDbMigrationsSqlGenerator : NpgsqlMigrationsSqlGenera
             .Append(" USING bm25 (")
             .Append(string.Join(", ", fields))
             .Append(") WITH (key_field = ")
-            .Append(
-                Dependencies
-                    .TypeMappingSource.FindMapping(typeof(string))!
-                    .GenerateSqlLiteral(keyField)
-            )
-            .Append(")");
+            .Append(stringMapping.GenerateSqlLiteral(keyField));
+
+        if (searchTokenizer is not null)
+        {
+            builder
+                .Append(", search_tokenizer = ")
+                .Append(stringMapping.GenerateSqlLiteral(searchTokenizer));
+        }
+
+        builder.Append(")");
 
         if (operation.Filter is not null)
         {

--- a/src/Internal/ParadeDbOptionsExtension.cs
+++ b/src/Internal/ParadeDbOptionsExtension.cs
@@ -1,8 +1,11 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.DependencyInjection;
 using ParadeDB.EntityFrameworkCore.Internal.Metadata;
+using ParadeDB.EntityFrameworkCore.Internal.Migrations;
 using ParadeDB.EntityFrameworkCore.Internal.Query;
 
 namespace ParadeDB.EntityFrameworkCore.Internal;
@@ -17,6 +20,8 @@ internal sealed class ParadeDbOptionsExtension : IDbContextOptionsExtension
     public void ApplyServices(IServiceCollection services)
     {
         services.AddScoped<IQuerySqlGeneratorFactory, ParadeDbQuerySqlGeneratorFactory>();
+        services.AddScoped<IMigrationsSqlGenerator, ParadeDbMigrationsSqlGenerator>();
+        services.AddSingleton<IRelationalAnnotationProvider, ParadeDbAnnotationProvider>();
         services.AddScoped<IMethodCallTranslatorPlugin, ParadeDbMethodCallTranslatorPlugin>();
         services.AddScoped<IMemberTranslatorPlugin, ParadeDbMemberTranslatorPlugin>();
         services.AddSingleton<IConventionSetPlugin, ParadeDbConventionSetPlugin>();

--- a/src/Tokenizer.cs
+++ b/src/Tokenizer.cs
@@ -41,11 +41,37 @@ public sealed class Tokenizer
         return args.Count == 0 ? $"pdb.{_name}" : $"pdb.{_name}({string.Join(",", args)})";
     }
 
+    internal string ToSearchString()
+    {
+        var args = _args.Concat(
+            _options.Select(option =>
+                $"{option.Key}={FormatSearchOptionValue(option.Value, option.Key)}"
+            )
+        );
+
+        var argsArray = args as string[] ?? args.ToArray();
+
+        return argsArray.Length == 0 ? _name : $"{_name}({string.Join(",", argsArray)})";
+    }
+
     private static string FormatOptionValue(object value, string key) =>
         value switch
         {
             bool b => b.ToString().ToLowerInvariant(),
             string s => Quote(s),
+            int n => n.ToString(CultureInfo.InvariantCulture),
+            float n => n.ToString(CultureInfo.InvariantCulture),
+            _ => throw new ArgumentException(
+                $"Tokenizer option '{key}' has unsupported value type '{value?.GetType().Name}'. Each tokenizer option value must be a bool, string, int, or float.",
+                "options"
+            ),
+        };
+
+    private static string FormatSearchOptionValue(object value, string key) =>
+        value switch
+        {
+            bool b => b.ToString().ToLowerInvariant(),
+            string s => s,
             int n => n.ToString(CultureInfo.InvariantCulture),
             float n => n.ToString(CultureInfo.InvariantCulture),
             _ => throw new ArgumentException(

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -49,8 +49,7 @@ public sealed class IndexingTest : TestBase
             """
             CREATE INDEX indexing_items_idx ON indexing_items (description);
 
-            """,
-            StringCompareShould.IgnoreLineEndings
+            """
         );
         await context.Database.ExecuteSqlRawAsync(sql);
     }
@@ -79,6 +78,8 @@ public sealed class IndexingTest : TestBase
                         "metadata ->> 'color'",
                         Tokenizer.Literal(new() { ["alias"] = "metadata_color" })
                     )
+                    .HasField(e => e.Rating, new FieldAlias("my_rating_alias"))
+                    .HasField("rating + 1", new FieldAlias("escape' me"))
                     .HasFilter("rating > 0");
             });
         }
@@ -104,10 +105,9 @@ public sealed class IndexingTest : TestBase
 
         sql.ShouldBe(
             """
-            CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, (description::pdb.ngram(3,3,'positions=true')), ((metadata ->> 'color')::pdb.literal('alias=metadata_color'))) WITH (key_field = 'id') WHERE rating > 0;
+            CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, (description::pdb.ngram(3,3,'positions=true')), ((metadata ->> 'color')::pdb.literal('alias=metadata_color')), (rating::pdb.alias('my_rating_alias')), ((rating + 1)::pdb.alias('escape'' me'))) WITH (key_field = 'id') WHERE rating > 0;
 
-            """,
-            StringCompareShould.IgnoreLineEndings
+            """
         );
         await context.Database.ExecuteSqlRawAsync(sql);
     }
@@ -155,8 +155,7 @@ public sealed class IndexingTest : TestBase
             """
             CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, description, metadata) WITH (key_field = 'id');
 
-            """,
-            StringCompareShould.IgnoreLineEndings
+            """
         );
         await context.Database.ExecuteSqlRawAsync(sql);
     }
@@ -216,8 +215,7 @@ public sealed class IndexingTest : TestBase
             """
             CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, categories, (tags::pdb.literal), ((description || ' ' || category)::pdb.simple('alias=description_concat')), (description::pdb.literal), (description::pdb.simple('alias=description_simple'))) WITH (key_field = 'id');
 
-            """,
-            StringCompareShould.IgnoreLineEndings
+            """
         );
         await context.Database.ExecuteSqlRawAsync(sql);
     }

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -127,6 +127,7 @@ public sealed class IndexingTest : TestBase
 
                 entity
                     .HasBm25Index("indexing_items_idx", e => e.Id)
+                    .IsCreatedConcurrently()
                     .HasField(e => e.Description)
                     .HasField(e => e.Metadata);
             });
@@ -153,7 +154,7 @@ public sealed class IndexingTest : TestBase
 
         sql.ShouldBe(
             """
-            CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, description, metadata) WITH (key_field = 'id');
+            CREATE INDEX CONCURRENTLY indexing_items_idx ON indexing_items USING bm25 (id, description, metadata) WITH (key_field = 'id');
 
             """
         );

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -80,7 +80,8 @@ public sealed class IndexingTest : TestBase
                     )
                     .HasField(e => e.Rating, new FieldAlias("my_rating_alias"))
                     .HasField("rating + 1", new FieldAlias("escape' me"))
-                    .HasFilter("rating > 0");
+                    .HasFilter("rating > 0")
+                    .HasSearchTokenizer(Tokenizer.Simple(new() { ["lowercase"] = false }));
             });
         }
     }
@@ -105,7 +106,7 @@ public sealed class IndexingTest : TestBase
 
         sql.ShouldBe(
             """
-            CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, (description::pdb.ngram(3,3,'positions=true')), ((metadata ->> 'color')::pdb.literal('alias=metadata_color')), (rating::pdb.alias('my_rating_alias')), ((rating + 1)::pdb.alias('escape'' me'))) WITH (key_field = 'id') WHERE rating > 0;
+            CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, (description::pdb.ngram(3,3,'positions=true')), ((metadata ->> 'color')::pdb.literal('alias=metadata_color')), (rating::pdb.alias('my_rating_alias')), ((rating + 1)::pdb.alias('escape'' me'))) WITH (key_field = 'id', search_tokenizer = 'simple(lowercase=false)') WHERE rating > 0;
 
             """
         );

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -222,6 +222,106 @@ public sealed class IndexingTest : TestBase
         await context.Database.ExecuteSqlRawAsync(sql);
     }
 
+    public static IEnumerable<(
+        Tokenizer Tokenizer,
+        string ExpectedSearchTokenizer
+    )> SearchTokenizerVariations()
+    {
+        yield return (
+            Tokenizer.Unicode(new() { ["remove_emojis"] = true }),
+            "unicode_words(remove_emojis=true)"
+        );
+        yield return (
+            Tokenizer.Simple(
+                new()
+                {
+                    ["stemmer"] = "english",
+                    ["max_token_length"] = 255,
+                    ["threshold"] = 2.3f,
+                }
+            ),
+            "simple(stemmer=english,max_token_length=255,threshold=2.3)"
+        );
+        yield return (Tokenizer.Icu(), "icu");
+        yield return (Tokenizer.ChineseCompatible([]), "chinese_compatible");
+        yield return (Tokenizer.Jieba(), "jieba");
+        yield return (Tokenizer.Literal(), "literal");
+        yield return (
+            Tokenizer.LiteralNormalized(new() { ["trim"] = true }),
+            "literal_normalized(trim=true)"
+        );
+        yield return (
+            Tokenizer.Ngram(3, 3, new() { ["positions"] = true, ["prefix_only"] = true }),
+            "ngram(3,3,positions=true,prefix_only=true)"
+        );
+        yield return (
+            Tokenizer.EdgeNgram(2, 5, new() { ["token_chars"] = "letter,digit,punctuation" }),
+            "edge_ngram(2,5,token_chars=letter,digit,punctuation)"
+        );
+        yield return (Tokenizer.RegexPattern("isn't", []), "regex_pattern(''isn''''t'')");
+        yield return (Tokenizer.SourceCode(), "source_code");
+        yield return (Tokenizer.Whitespace(), "whitespace");
+    }
+
+    private sealed class SearchTokenizerIndexContext(
+        DbContextOptions<SearchTokenizerIndexContext> options,
+        Tokenizer tokenizer
+    ) : DbContext(options)
+    {
+        public Tokenizer Tokenizer { get; } = tokenizer;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("indexing_items");
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Description).HasColumnName("description");
+
+                entity
+                    .HasBm25Index("indexing_items_idx", e => e.Id)
+                    .HasField(e => e.Description)
+                    .HasSearchTokenizer(Tokenizer);
+            });
+        }
+    }
+
+    private sealed class SearchTokenizerIndexModelCacheKeyFactory : IModelCacheKeyFactory
+    {
+        public object Create(DbContext context, bool designTime) =>
+            context is SearchTokenizerIndexContext searchTokenizerContext
+                ? (context.GetType(), searchTokenizerContext.Tokenizer.ToString(), designTime)
+                : (context.GetType(), designTime);
+
+        public object Create(DbContext context) => Create(context, false);
+    }
+
+    [Test]
+    [MethodDataSource(nameof(SearchTokenizerVariations))]
+    public async Task Bm25Index_SearchTokenizerRendersTokenizer(
+        Tokenizer tokenizer,
+        string expectedSearchTokenizer
+    )
+    {
+        await using var context = DbFixture.CreateContext();
+        await context.Database.OpenConnectionAsync();
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TEMP TABLE indexing_items (
+                id int PRIMARY KEY,
+                description text
+            );
+            """
+        );
+
+        var sql = GenerateSearchTokenizerCreateIndexSql(tokenizer);
+
+        sql.ShouldBe(
+            $"CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, description) WITH (key_field = 'id', search_tokenizer = '{expectedSearchTokenizer}');\n"
+        );
+        await context.Database.ExecuteSqlRawAsync(sql);
+    }
+
     private static string GenerateCreateIndexSql<TContext, TEntity>()
         where TContext : DbContext
     {
@@ -235,6 +335,30 @@ public sealed class IndexingTest : TestBase
         var model = context.GetService<IDesignTimeModel>().Model;
         var index = model
             .FindEntityType(typeof(TEntity))!
+            .GetIndexes()
+            .Single(i => i.GetDatabaseName() == "indexing_items_idx")
+            .GetMappedTableIndexes()
+            .Single();
+
+        return context
+            .GetService<IMigrationsSqlGenerator>()
+            .Generate([CreateIndexOperation.CreateFrom(index)], model)
+            .Single()
+            .CommandText;
+    }
+
+    private static string GenerateSearchTokenizerCreateIndexSql(Tokenizer tokenizer)
+    {
+        using var context = new SearchTokenizerIndexContext(
+            new DbContextOptionsBuilder<SearchTokenizerIndexContext>()
+                .UseNpgsql("Host=localhost;Database=test", o => o.UseParadeDb())
+                .ReplaceService<IModelCacheKeyFactory, SearchTokenizerIndexModelCacheKeyFactory>()
+                .Options,
+            tokenizer
+        );
+        var model = context.GetService<IDesignTimeModel>().Model;
+        var index = model
+            .FindEntityType(typeof(IndexingItem))!
             .GetIndexes()
             .Single(i => i.GetDatabaseName() == "indexing_items_idx")
             .GetMappedTableIndexes()

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -1,0 +1,260 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using ParadeDB.EntityFrameworkCore.Extensions;
+using Shouldly;
+
+namespace ParadeDB.EntityFrameworkCore.Tests;
+
+public sealed class IndexingTest : TestBase
+{
+    private sealed class RegularIndexContext(DbContextOptions<RegularIndexContext> options)
+        : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("indexing_items");
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Description).HasColumnName("description");
+
+                entity.HasIndex(e => e.Description).HasDatabaseName("indexing_items_idx");
+            });
+        }
+    }
+
+    // We include a regular index here to check that the code changes to support bm25 indexes aren't inadvertently
+    // breaking regular ones
+    [Test]
+    public async Task RegularIndex()
+    {
+        await using var context = DbFixture.CreateContext();
+        await context.Database.OpenConnectionAsync();
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TEMP TABLE indexing_items (
+                id int PRIMARY KEY,
+                description text
+            );
+            """
+        );
+
+        var sql = GenerateCreateIndexSql<RegularIndexContext, IndexingItem>();
+
+        sql.ShouldBe(
+            """
+            CREATE INDEX indexing_items_idx ON indexing_items (description);
+
+            """,
+            StringCompareShould.IgnoreLineEndings
+        );
+        await context.Database.ExecuteSqlRawAsync(sql);
+    }
+
+    private sealed class JsonExpressionIndexContext(
+        DbContextOptions<JsonExpressionIndexContext> options
+    ) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("indexing_items");
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Description).HasColumnName("description");
+                entity.Property(e => e.Metadata).HasColumnName("metadata");
+                entity.Property(e => e.Rating).HasColumnName("rating");
+
+                entity
+                    .HasBm25Index("indexing_items_idx", e => e.Id)
+                    .HasField(
+                        e => e.Description,
+                        Tokenizer.Ngram(3, 3, new() { ["positions"] = true })
+                    )
+                    .HasField(
+                        "metadata ->> 'color'",
+                        Tokenizer.Literal(new() { ["alias"] = "metadata_color" })
+                    )
+                    .HasFilter("rating > 0");
+            });
+        }
+    }
+
+    [Test]
+    public async Task Bm25Index_WithJsonExpressionTokenizerOptionsAndFilter()
+    {
+        await using var context = DbFixture.CreateContext();
+        await context.Database.OpenConnectionAsync();
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TEMP TABLE indexing_items (
+                id int PRIMARY KEY,
+                description text,
+                metadata jsonb,
+                rating int
+            );
+            """
+        );
+
+        var sql = GenerateCreateIndexSql<JsonExpressionIndexContext, IndexingItem>();
+
+        sql.ShouldBe(
+            """
+            CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, (description::pdb.ngram(3,3,'positions=true')), ((metadata ->> 'color')::pdb.literal('alias=metadata_color'))) WITH (key_field = 'id') WHERE rating > 0;
+
+            """,
+            StringCompareShould.IgnoreLineEndings
+        );
+        await context.Database.ExecuteSqlRawAsync(sql);
+    }
+
+    private sealed class SimpleIndexContext(DbContextOptions<SimpleIndexContext> options)
+        : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("indexing_items");
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Description).HasColumnName("description");
+                entity.Property(e => e.Metadata).HasColumnName("metadata");
+                entity.Property(e => e.Rating).HasColumnName("rating");
+
+                entity
+                    .HasBm25Index("indexing_items_idx", e => e.Id)
+                    .HasField(e => e.Description)
+                    .HasField(e => e.Metadata);
+            });
+        }
+    }
+
+    [Test]
+    public async Task SimpleBm25Index()
+    {
+        await using var context = DbFixture.CreateContext();
+        await context.Database.OpenConnectionAsync();
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TEMP TABLE indexing_items (
+                id int PRIMARY KEY,
+                description text,
+                metadata jsonb,
+                rating int
+            );
+            """
+        );
+
+        var sql = GenerateCreateIndexSql<SimpleIndexContext, IndexingItem>();
+
+        sql.ShouldBe(
+            """
+            CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, description, metadata) WITH (key_field = 'id');
+
+            """,
+            StringCompareShould.IgnoreLineEndings
+        );
+        await context.Database.ExecuteSqlRawAsync(sql);
+    }
+
+    private sealed class ArrayExpressionIndexContext(
+        DbContextOptions<ArrayExpressionIndexContext> options
+    ) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("indexing_items");
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Description).HasColumnName("description");
+                entity.Property(e => e.Category).HasColumnName("category");
+                entity.Property(e => e.Categories).HasColumnName("categories");
+                entity.Property(e => e.Tags).HasColumnName("tags");
+
+                entity
+                    .HasBm25Index("indexing_items_idx", e => e.Id)
+                    .HasField(e => e.Categories)
+                    .HasField(e => e.Tags, Tokenizer.Literal())
+                    .HasField(
+                        "description || ' ' || category",
+                        Tokenizer.Simple(new() { ["alias"] = "description_concat" })
+                    )
+                    .HasField(e => e.Description, Tokenizer.Literal())
+                    .HasField(
+                        e => e.Description,
+                        Tokenizer.Simple(new() { ["alias"] = "description_simple" })
+                    );
+            });
+        }
+    }
+
+    [Test]
+    public async Task Bm25Index_WithArrayExpressionAndMultipleTokenizers()
+    {
+        await using var context = DbFixture.CreateContext();
+        await context.Database.OpenConnectionAsync();
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TEMP TABLE indexing_items (
+                id int PRIMARY KEY,
+                description text,
+                category text,
+                categories text[],
+                tags varchar(255)[]
+            );
+            """
+        );
+
+        var sql = GenerateCreateIndexSql<ArrayExpressionIndexContext, IndexingItem>();
+
+        sql.ShouldBe(
+            """
+            CREATE INDEX indexing_items_idx ON indexing_items USING bm25 (id, categories, (tags::pdb.literal), ((description || ' ' || category)::pdb.simple('alias=description_concat')), (description::pdb.literal), (description::pdb.simple('alias=description_simple'))) WITH (key_field = 'id');
+
+            """,
+            StringCompareShould.IgnoreLineEndings
+        );
+        await context.Database.ExecuteSqlRawAsync(sql);
+    }
+
+    private static string GenerateCreateIndexSql<TContext, TEntity>()
+        where TContext : DbContext
+    {
+        using var context = (TContext)
+            Activator.CreateInstance(
+                typeof(TContext),
+                new DbContextOptionsBuilder<TContext>()
+                    .UseNpgsql("Host=localhost;Database=test", o => o.UseParadeDb())
+                    .Options
+            )!;
+        var model = context.GetService<IDesignTimeModel>().Model;
+        var index = model
+            .FindEntityType(typeof(TEntity))!
+            .GetIndexes()
+            .Single(i => i.GetDatabaseName() == "indexing_items_idx")
+            .GetMappedTableIndexes()
+            .Single();
+
+        return context
+            .GetService<IMigrationsSqlGenerator>()
+            .Generate([CreateIndexOperation.CreateFrom(index)], model)
+            .Single()
+            .CommandText;
+    }
+
+    private sealed class IndexingItem
+    {
+        public int Id { get; set; }
+        public string Description { get; set; } = "";
+        public string Category { get; set; } = "";
+        public string[] Categories { get; set; } = [];
+        public string[] Tags { get; set; } = [];
+        public JsonDocument? Metadata { get; set; }
+        public int Rating { get; set; }
+    }
+}


### PR DESCRIPTION
# Ticket(s) Closed

Adds support for index management using a custom migration SQL generator. Uses a fluent API similar to the normal way indexes are configured.

## What

## Why

## How

## Tests
