### PR TITLE
chore: replace no-op final-newline lint with a real check; drop irrelevant excludes

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -34,25 +34,23 @@ jobs:
 
       - name: Check for Trailing Whitespaces
         run: |
-          FILES=$(git grep -Ilr '[[:blank:]]$' -- \
-            ':(exclude)*.nix' \
-            ':(exclude)*.sql' \
-            ':(exclude)*.out' \
-            ':(exclude)*.rs' \
-            ':(exclude)docker/manifests/**' || true)
+          FILES=$(git grep -Ilr '[[:blank:]]$' || true)
           if [[ ! -z "$FILES" ]]; then
             echo "The following files have trailing whitespaces:"
             echo "$FILES"
             exit 1
           fi
 
-      - name: Print Modified Files
+      - name: Check for Missing Final Newlines
         run: |
-          FILES=$(git ls-files --modified)
-          if [[ ! -z "$FILES" ]]; then
-            echo "The following files have incorrect trailing newlines:"
-            echo "$FILES"
-            echo "Please fix them using:"
-            echo -e 'if [[ -f "$1" ]]; then\n  echo -n "$1"\n  if (diff /dev/null "$1" || true) | tail -1 | grep -q "^\\ No newline"; then\n    echo >> "$1"\n    echo "...fixed"\n  else\n    echo ""\n  fi\nfi'
-            false
+          MISSING=""
+          while IFS= read -r file; do
+            if [[ -s "$file" && -n "$(tail -c1 "$file")" ]]; then
+              MISSING="${MISSING}${file}"$'\n'
+            fi
+          done < <(git grep -Il '.')
+          if [[ -n "$MISSING" ]]; then
+            echo "The following files are missing a trailing newline:"
+            echo "$MISSING"
+            exit 1
           fi


### PR DESCRIPTION
## Problem

The `lint-format.yml` **Print Modified Files** step ran `git ls-files --modified` — which lists files differing between the working tree and the index. On a fresh CI checkout nothing is modified, so it was **always empty**: the step passed unconditionally and never actually checked anything.

## Fix

1. Replace it with a real, binary-safe **Check for Missing Final Newlines** step (`git grep -Il` lists tracked text files; fails CI if any lacks a trailing newline).
2. **Drop the irrelevant exclude list** from *both* lint steps. The `:(exclude)*.nix/*.sql/*.out/*.rs` (+`docker/manifests`) excludes were copied from paradedb (a Rust/Postgres repo) and dont apply here — this repo has none of those types. Both checks now cover all tracked text files.

Verified **0 violations** for both checks on the current tree, so CI stays green.

Part of an org-wide sweep (mirrors paradedb/paradedb#5324).