### PR TITLE
fix(ci): forward coverlet.MTP coverage args after `--` so coverage is actually collected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,16 @@ jobs:
         run: dotnet build build.slnf --configuration Release --framework ${{ matrix.framework }} --no-restore
 
       - name: Test
+        # coverlet.MTP is a Microsoft.Testing.Platform extension, so its
+        # arguments must be forwarded to the test application after `--`.
+        # Coverage reports are written into --results-directory.
         run: |
           dotnet test \
             --no-build \
             --configuration Release \
             --framework ${{ matrix.framework }} \
             --results-directory TestResults/${{ matrix.framework }} \
+            -- \
             --coverlet \
             --coverlet-output-format cobertura
 

--- a/.github/workflows/schema-compat.yml
+++ b/.github/workflows/schema-compat.yml
@@ -66,12 +66,16 @@ jobs:
         run: dotnet build build.slnf --configuration Release --framework net10.0 --no-restore
 
       - name: Test
+        # coverlet.MTP is a Microsoft.Testing.Platform extension, so its
+        # arguments must be forwarded to the test application after `--`.
+        # Coverage reports are written into --results-directory.
         run: |
           dotnet test \
             --no-build \
             --configuration Release \
             --framework net10.0 \
             --results-directory TestResults/net10.0 \
+            -- \
             --coverlet \
             --coverlet-output-format cobertura
 


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` (Test step) and `.github/workflows/schema-compat.yml` (Test step) passed coverage flags as **top-level `dotnet test` arguments**:

```yaml
dotnet test \
  --no-build --configuration Release \
  --framework ... --results-directory TestResults/... \
  --coverlet \
  --coverlet-output-format cobertura
```

This project's test suite uses **TUnit + `coverlet.MTP`**, i.e. it runs on **Microsoft.Testing.Platform (MTP)**. `--coverlet` / `--coverlet-output-format` are options provided by the `coverlet.MTP` *extension*, not by `dotnet test` itself. When placed at the top level they are handled by `dotnet test`'s own argument parser (not forwarded reliably to the test application), so coverage was never collected and the **Codecov upload step was a no-op** — no cobertura report was ever produced in `--results-directory`.

## Root cause / how I verified it

- **Coverage package:** `coverlet.MTP` v10.0.1 — declared in `Directory.Packages.props` and referenced in `tests/ParadeDB.EntityFrameworkCore.Tests.csproj`. (Not `coverlet.collector` and not `coverlet.msbuild`, so `--collect:"XPlat Code Coverage"` and msbuild `/p:CollectCoverage` would both be wrong here.)
- **Runner:** TUnit + `<OutputType>Exe</OutputType>` → Microsoft.Testing.Platform. `global.json` sets `"test": { "runner": "Microsoft.Testing.Platform" }`, so `dotnet test` runs in MTP mode on the .NET 10 SDK.
- Per the official [`dotnet test` MTP docs](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-dotnet-test), arguments meant for the test application / MTP extensions are forwarded **after a `--` separator** (`dotnet test -- <app args>`). Using the separator also avoids the documented parser quirk where unrecognized tokens interleaved with options `dotnet test` understands (`--results-directory`, `--framework`) change meaning.
- Per the [coverlet.MTP integration docs](https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/Coverlet.MTP.Integration.md), the flag names `--coverlet` and `--coverlet-output-format cobertura` are correct, and coverage reports are written into the `--results-directory` folder with a timestamped filename (e.g. `coverage.cobertura.<timestamp>.xml`). There is no separate output-path flag.

## Fix

Forward the coverlet flags after `--` in both workflows (no other changes):

```yaml
dotnet test \
  --no-build --configuration Release \
  --framework ... --results-directory TestResults/... \
  -- \
  --coverlet \
  --coverlet-output-format cobertura
```

The Codecov upload step already points `directory:` at the same `--results-directory`, and since coverlet emits a timestamped filename there, scanning the directory (rather than a hardcoded filename) remains the correct approach — no change needed to the upload step.

## Validation

- Both workflow files parse as valid YAML (`python3 -c "import yaml; ..."`).
- The .NET SDK is **not** available in my environment, so I could **not** run the full build + test + coverage locally. **Please watch this PR's first CI run** to confirm a `coverage.cobertura.*.xml` is produced under `TestResults/<framework>/` and that the Codecov upload picks it up (the `verbose: true` Codecov step output will show the discovered file).

Filed from a CI audit of bogus `dotnet test` flags.