### PR TITLE
docs: Update README to match new positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- ParadeDB: Search without a second system -->
 <h1 align="center">
   <a href="https://paradedb.com">
     <picture align=center>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## ParadeDB for Entity Framework Core
 
-The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com), including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. ParadeDB is powered by [`pg_search`](https://github.com/paradedb/paradedb), a Postgres extension that adds Elastic-quality full-text search, vector retrieval, and aggregations. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
+The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
 
 ## Requirements & Compatibility
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-<!-- ParadeDB: Postgres for Search and Analytics -->
+<!-- ParadeDB: Search without a second system -->
 <h1 align="center">
-  <a href="https://paradedb.com"><img src="https://github.com/paradedb/paradedb/raw/main/docs/logo/readme.svg" alt="ParadeDB"></a>
-<br>
+  <a href="https://paradedb.com">
+    <picture align=center>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/paradedb/paradedb/raw/main/docs/logo/paradedb-logo-dark-large.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://github.com/paradedb/paradedb/raw/main/docs/logo/paradedb-logo-light-large.svg">
+      <img alt="The ParadeDB logo." src="https://github.com/paradedb/paradedb/raw/main/docs/logo/paradedb-logo-light-large.svg">
+    </picture>
+  </a>
+  <br>
 </h1>
 
 <p align="center">
-  <b>Simple, Elastic-quality search for Postgres</b><br/>
+  <b>Search without a second system.</b><br/>
+  One Postgres for your application data, full-text search, vector retrieval, and aggregations.
 </p>
 
 <h3 align="center">
@@ -30,7 +37,7 @@
 
 ## ParadeDB for Entity Framework Core
 
-The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com), including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
+The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB / pg_search](https://paradedb.com), including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
 
 ## Requirements & Compatibility
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## ParadeDB for Entity Framework Core
 
-The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB / pg_search](https://paradedb.com), including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
+The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com), including first-class support for managing BM25 indexes and running queries using the full ParadeDB API. ParadeDB is powered by [`pg_search`](https://github.com/paradedb/paradedb), a Postgres extension that adds Elastic-quality full-text search, vector retrieval, and aggregations. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
 
 ## Requirements & Compatibility
 


### PR DESCRIPTION
Updates the README to match the new positioning from paradedb/paradedb#5483:

- New tagline ("Search without a second system.") and one-Postgres sub-line
- New large light/dark logo variants
- Intro now links "ParadeDB / pg_search" as a single link