### PR TITLE
fix: point the nuget dependabot entry at the project directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,14 @@ updates:
         patterns:
           - "*"
 
+  # The project files, not "/": the root has no .csproj and Dependabot does not read the .slnx
+  # solution format, so nothing was discovered there. Central Package Management means the versions
+  # these resolve to live in Directory.Packages.props, which is what actually gets updated.
   - package-ecosystem: "nuget"
-    directory: "/"
+    directories:
+      - "/src"
+      - "/tests"
+      - "/examples"
     schedule:
       interval: "monthly"
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,6 @@ updates:
         patterns:
           - "*"
 
-  # The project files, not "/": the root has no .csproj and Dependabot does not read the .slnx
-  # solution format, so nothing was discovered there. Central Package Management means the versions
-  # these resolve to live in Directory.Packages.props, which is what actually gets updated.
   - package-ecosystem: "nuget"
     directories:
       - "/src"


### PR DESCRIPTION
## What

`nuget` goes from `directory: "/"` to `directories: ["/src", "/tests", "/examples"]`. From the org-wide audit behind paradedb/cloud#305.

## Why

The `nuget` entry looks correct but **has never produced a single PR** in the repo's ten months. It's a config that reads as coverage while providing none.

The pins have drifted in the meantime — all minor bumps, which the patch-only ignore does *not* cover, so they should have been offered:

| package | pinned | latest |
|---|---|---|
| TUnit | 1.43.11 | **1.61.0** |
| Testcontainers.PostgreSql | 4.11.0 | 4.13.0 |
| Scalar.AspNetCore | 2.14.0 | 2.16.15 |

## How

`/` has no `.csproj`, and the only solution file is `ParadeDB.EntityFrameworkCore.slnx` — the newer XML format, which Dependabot doesn't read (there's no classic `.sln`). So it discovered no projects at the root and quietly did nothing.

Pointing at the three directories that actually hold a `.csproj` gives it something to find. Central Package Management (`ManagePackageVersionsCentrally`) means those resolve versions from `Directory.Packages.props`, so that's the file the updates will land in — `/examples` additionally has its own, which imports the root and adds Pgvector.

## Worth watching on the first run

All three projects share the root `Directory.Packages.props`. They're in one group (`nuget-dependencies`), so I'd expect a single grouped PR "across 3 directories" rather than three PRs racing on the same file — but I can't verify that locally, and it's the thing most likely to need tuning. If it does come out noisy, narrowing to `/src` and `/tests` would still cover everything the library ships.

## Tests

Prettier-clean, parses under `yq`, and each listed directory confirmed to hold exactly one `.csproj`. Dependabot behavior can't be exercised locally; the real proof is the next monthly run. Expect a chunky first batch.

https://claude.ai/code/session_01Mzkzx3hJsXN26mZZ8RXdEX