### PR TITLE
feat: native vector search support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- Native vector search support: `vector(n)` column mapping for `float[]`
+  properties (`HasVectorType`), vector fields with metric operator classes in
+  ParadeDB indexes (`HasField(..., VectorMetric)`), and the `L2Distance`,
+  `CosineDistance`, and `InnerProduct` distance functions.
+
 ### Changed
 
 - **Breaking**: `HasBm25Index` and `Bm25IndexBuilder<TEntity>` are renamed to

--- a/NUGET-README.md
+++ b/NUGET-README.md
@@ -1,24 +1,25 @@
 # ParadeDB for Entity Framework Core
 
-The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
+The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. The integration covers both full-text search and [vector search](https://docs.paradedb.com/documentation/vector/overview) over pgvector `vector` types. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
 
 ## Requirements & Compatibility
 
-| Component  | Supported                     |
-| ---------- | ----------------------------- |
-| .NET       | 8.0+                          |
-| EF Core    | 8.0+                          |
-| ParadeDB   | 0.25.0+                       |
-| PostgreSQL | 15+ (with ParadeDB extension) |
+| Component  | Supported                                                         |
+| ---------- | ----------------------------------------------------------------- |
+| .NET       | 8.0+                                                              |
+| EF Core    | 8.0+                                                              |
+| ParadeDB   | 0.25.0+                                                           |
+| PostgreSQL | 15+ (with ParadeDB extension)                                     |
+| pgvector   | Required for vector search; included in the ParadeDB Docker image |
 
 ## Examples
 
 - [Quickstart](examples/Quickstart/Program.cs)
+- [Vector Search](examples/VectorSearch/Program.cs)
 - [Faceted Search](examples/FacetedSearch/Program.cs)
 - [Autocomplete](examples/Autocomplete/Program.cs)
 - [More Like This](examples/MoreLikeThis/Program.cs)
 - [Hybrid Search (RRF)](examples/HybridRrf/Program.cs)
-- [Vector Search](examples/VectorSearch/Program.cs)
 - [RAG](examples/Rag/Program.cs)
 
 ## Contributing

--- a/NUGET-README.md
+++ b/NUGET-README.md
@@ -18,6 +18,7 @@ The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/)
 - [Autocomplete](examples/Autocomplete/Program.cs)
 - [More Like This](examples/MoreLikeThis/Program.cs)
 - [Hybrid Search (RRF)](examples/HybridRrf/Program.cs)
+- [Vector Search](examples/VectorSearch/Program.cs)
 - [RAG](examples/Rag/Program.cs)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -36,68 +36,26 @@
 
 ## ParadeDB for Entity Framework Core
 
-The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
+The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. The integration covers both full-text search and [vector search](https://docs.paradedb.com/documentation/vector/overview) over pgvector `vector` types. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#entity-framework-core) to begin.
 
 ## Requirements & Compatibility
 
-| Component  | Supported                     |
-| ---------- | ----------------------------- |
-| .NET       | 8.0+                          |
-| EF Core    | 8.0+                          |
-| ParadeDB   | 0.25.0+                       |
-| PostgreSQL | 15+ (with ParadeDB extension) |
-
-## Vector Search
-
-ParadeDB indexes pgvector `vector` columns directly inside its BM25 index — no
-pgvector ORM plugin is required. Map a `float[]` property to a `vector(n)`
-column, pick a distance metric for the index, and order by the matching
-distance function:
-
-```csharp
-public class Item
-{
-    public int Id { get; set; }
-    public float[]? Embedding { get; set; }
-}
-
-// Model configuration
-modelBuilder.Entity<Item>(entity =>
-{
-    entity.Property(x => x.Embedding).HasVectorType(384);
-
-    entity
-        .HasParadeDbIndex("items_idx", x => x.Id)
-        .HasField(x => x.Embedding, VectorMetric.Cosine);
-});
-
-// Top-K query: a `@@@` predicate (`EF.Functions.All` for match-all here) and
-// a LIMIT (`Take`) are required for the index to serve the query
-float[] queryEmbedding = GetQueryEmbedding();
-
-var results = await db
-    .Items.Where(x => EF.Functions.All(x.Id))
-    .OrderBy(x => EF.Functions.CosineDistance(x.Embedding, queryEmbedding))
-    .Take(10)
-    .ToListAsync();
-```
-
-`VectorMetric.L2` (`<->`, the default), `VectorMetric.Cosine` (`<=>`), and
-`VectorMetric.InnerProduct` (`<#>`) map to the `vector_l2_ops`,
-`vector_cosine_ops`, and `vector_ip_ops` operator classes. The distance
-function used in `OrderBy` must match the metric of the index opclass —
-`L2Distance` with `L2`, `CosineDistance` with `Cosine`, and `InnerProduct`
-with `InnerProduct` — otherwise the query still returns correct results but
-falls back to a sequential scan instead of Top-K index pushdown.
+| Component  | Supported                                                         |
+| ---------- | ----------------------------------------------------------------- |
+| .NET       | 8.0+                                                              |
+| EF Core    | 8.0+                                                              |
+| ParadeDB   | 0.25.0+                                                           |
+| PostgreSQL | 15+ (with ParadeDB extension)                                     |
+| pgvector   | Required for vector search; included in the ParadeDB Docker image |
 
 ## Examples
 
 - [Quickstart](examples/Quickstart/Program.cs)
+- [Vector Search](examples/VectorSearch/Program.cs)
 - [Faceted Search](examples/FacetedSearch/Program.cs)
 - [Autocomplete](examples/Autocomplete/Program.cs)
 - [More Like This](examples/MoreLikeThis/Program.cs)
 - [Hybrid Search (RRF)](examples/HybridRrf/Program.cs)
-- [Vector Search](examples/VectorSearch/Program.cs)
 - [RAG](examples/Rag/Program.cs)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -47,6 +47,49 @@ The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/)
 | ParadeDB   | 0.25.0+                       |
 | PostgreSQL | 15+ (with ParadeDB extension) |
 
+## Vector Search
+
+ParadeDB indexes pgvector `vector` columns directly inside its BM25 index — no
+pgvector ORM plugin is required. Map a `float[]` property to a `vector(n)`
+column, pick a distance metric for the index, and order by the matching
+distance function:
+
+```csharp
+public class Item
+{
+    public int Id { get; set; }
+    public float[]? Embedding { get; set; }
+}
+
+// Model configuration
+modelBuilder.Entity<Item>(entity =>
+{
+    entity.Property(x => x.Embedding).HasVectorType(384);
+
+    entity
+        .HasParadeDbIndex("items_idx", x => x.Id)
+        .HasField(x => x.Embedding, VectorMetric.Cosine);
+});
+
+// Top-K query: a `@@@` predicate (`EF.Functions.All` for match-all here) and
+// a LIMIT (`Take`) are required for the index to serve the query
+float[] queryEmbedding = GetQueryEmbedding();
+
+var results = await db
+    .Items.Where(x => EF.Functions.All(x.Id))
+    .OrderBy(x => EF.Functions.CosineDistance(x.Embedding, queryEmbedding))
+    .Take(10)
+    .ToListAsync();
+```
+
+`VectorMetric.L2` (`<->`, the default), `VectorMetric.Cosine` (`<=>`), and
+`VectorMetric.InnerProduct` (`<#>`) map to the `vector_l2_ops`,
+`vector_cosine_ops`, and `vector_ip_ops` operator classes. The distance
+function used in `OrderBy` must match the metric of the index opclass —
+`L2Distance` with `L2`, `CosineDistance` with `Cosine`, and `InnerProduct`
+with `InnerProduct` — otherwise the query still returns correct results but
+falls back to a sequential scan instead of Top-K index pushdown.
+
 ## Examples
 
 - [Quickstart](examples/Quickstart/Program.cs)
@@ -54,6 +97,7 @@ The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/)
 - [Autocomplete](examples/Autocomplete/Program.cs)
 - [More Like This](examples/MoreLikeThis/Program.cs)
 - [Hybrid Search (RRF)](examples/HybridRrf/Program.cs)
+- [Vector Search](examples/VectorSearch/Program.cs)
 - [RAG](examples/Rag/Program.cs)
 
 ## Contributing

--- a/examples/Directory.Packages.props
+++ b/examples/Directory.Packages.props
@@ -1,7 +1,3 @@
 <Project>
   <Import Project="..\Directory.Packages.props" />
-
-  <ItemGroup>
-    <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
-  </ItemGroup>
 </Project>

--- a/examples/Examples.csproj
+++ b/examples/Examples.csproj
@@ -12,14 +12,13 @@
   </PropertyGroup>
 
   <Target Name="RequireExample" BeforeTargets="CoreCompile" Condition="'$(Example)' == ''">
-    <Error Text="Set the Example property to one of: Quickstart, FacetedSearch, Autocomplete, MoreLikeThis, HybridRrf, Rag." />
+    <Error Text="Set the Example property to one of: Quickstart, FacetedSearch, Autocomplete, MoreLikeThis, HybridRrf, VectorSearch, Rag." />
   </Target>
 
   <ItemGroup>
     <PackageReference Include="EFCore.NamingConventions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="Pgvector.EntityFrameworkCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Examples.csproj
+++ b/examples/Examples.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <Target Name="RequireExample" BeforeTargets="CoreCompile" Condition="'$(Example)' == ''">
-    <Error Text="Set the Example property to one of: Quickstart, FacetedSearch, Autocomplete, MoreLikeThis, HybridRrf, VectorSearch, Rag." />
+    <Error Text="Set the Example property to one of: Quickstart, VectorSearch, FacetedSearch, Autocomplete, MoreLikeThis, HybridRrf, Rag." />
   </Target>
 
   <ItemGroup>

--- a/examples/HybridRrf/Data/MockItemWithEmbedding.cs
+++ b/examples/HybridRrf/Data/MockItemWithEmbedding.cs
@@ -1,9 +1,8 @@
-using Pgvector;
 using Shared;
 
 namespace HybridRrf.Data;
 
 public class MockItemWithEmbedding : MockItem
 {
-    public Vector? Embedding { get; set; }
+    public float[]? Embedding { get; set; }
 }

--- a/examples/HybridRrf/Program.cs
+++ b/examples/HybridRrf/Program.cs
@@ -1,19 +1,10 @@
 using HybridRrf.Data;
 using Microsoft.EntityFrameworkCore;
 using ParadeDB.EntityFrameworkCore.Extensions;
-using Pgvector;
-using Pgvector.EntityFrameworkCore;
 using Shared;
 
 var options = new DbContextOptionsBuilder<AppDbContext>()
-    .UseNpgsql(
-        ExampleSetup.ConnectionString,
-        o =>
-        {
-            o.UseParadeDb();
-            o.UseVector();
-        }
-    )
+    .UseNpgsql(ExampleSetup.ConnectionString, o => o.UseParadeDb())
     .UseSnakeCaseNamingConvention()
     .Options;
 
@@ -52,7 +43,7 @@ static async Task Demo(AppDbContext db, string query, string seedDescription)
 static async Task<List<(string Description, double RrfScore)>> HybridSearch(
     AppDbContext db,
     string query,
-    Vector queryEmbedding,
+    float[] queryEmbedding,
     int topK = 20,
     int rrfK = 60,
     int limit = 5
@@ -71,12 +62,12 @@ static async Task<List<(string Description, double RrfScore)>> HybridSearch(
         .ToListAsync();
 
     var semantic = await db
-        .MockItems.Where(x => x.Embedding != null)
+        .MockItems.Where(x => EF.Functions.All(x.Id))
         .Select(x => new
         {
             x.Id,
             x.Description,
-            Distance = x.Embedding!.CosineDistance(queryEmbedding),
+            Distance = EF.Functions.CosineDistance(x.Embedding, queryEmbedding),
         })
         .OrderBy(x => x.Distance)
         .Take(topK)

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,15 @@ scoring, and highlighting.
 dotnet run --project examples/Examples.csproj -p:Example=Quickstart
 ```
 
+## Vector Search (`examples/VectorSearch`)
+
+Runs Top-K nearest-neighbor queries over a pgvector column with ParadeDB
+vector support, backed by a paradedb index.
+
+```bash
+dotnet run --project examples/Examples.csproj -p:Example=VectorSearch
+```
+
 ## Faceted Search (`examples/FacetedSearch`)
 
 Builds an e-commerce-style filtering sidebar with facet counts alongside
@@ -45,15 +54,6 @@ ranking.
 
 ```bash
 dotnet run --project examples/Examples.csproj -p:Example=HybridRrf
-```
-
-## Vector Search (`examples/VectorSearch`)
-
-Runs Top-K nearest-neighbor queries over a pgvector column with the native
-vector support, backed by a bm25 index when the server supports it.
-
-```bash
-dotnet run --project examples/Examples.csproj -p:Example=VectorSearch
 ```
 
 ## RAG: Retrieval-Augmented Generation (`examples/Rag`)

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,15 @@ ranking.
 dotnet run --project examples/Examples.csproj -p:Example=HybridRrf
 ```
 
+## Vector Search (`examples/VectorSearch`)
+
+Runs Top-K nearest-neighbor queries over a pgvector column with the native
+vector support, backed by a bm25 index when the server supports it.
+
+```bash
+dotnet run --project examples/Examples.csproj -p:Example=VectorSearch
+```
+
 ## RAG: Retrieval-Augmented Generation (`examples/Rag`)
 
 Builds a small QA flow that retrieves relevant context and sends it to an LLM

--- a/examples/VectorSearch/Program.cs
+++ b/examples/VectorSearch/Program.cs
@@ -1,0 +1,58 @@
+using HybridRrf.Data;
+using Microsoft.EntityFrameworkCore;
+using ParadeDB.EntityFrameworkCore.Extensions;
+using Shared;
+
+var options = new DbContextOptionsBuilder<AppDbContext>()
+    .UseNpgsql(ExampleSetup.ConnectionString, o => o.UseParadeDb())
+    .UseSnakeCaseNamingConvention()
+    .Options;
+
+await using var dbContext = new AppDbContext(options);
+
+Console.WriteLine(new string('=', 70));
+Console.WriteLine("Vector Search");
+Console.WriteLine(new string('=', 70));
+Console.WriteLine("\nTop-K nearest-neighbor search over a pgvector column");
+
+// The shared search_idx created here covers the embedding column with the
+// cosine metric, so it serves the vector queries below
+await ExampleSetup.SetupMockItemsAsync(dbContext);
+
+await Demo(dbContext, "Sleek running shoes");
+await Demo(dbContext, "Innovative wireless earbuds");
+return;
+
+static async Task Demo(AppDbContext db, string seedDescription)
+{
+    // The mock_items table ships with a pre-populated embedding column; use the
+    // embedding of a known item as the query vector
+    var queryEmbedding = await db
+        .MockItems.Where(x => x.Description == seedDescription)
+        .Select(x => x.Embedding!)
+        .FirstAsync();
+
+    // The @@@ predicate (EF.Functions.All) and the LIMIT are required for the
+    // ParadeDB index to serve the query; the ORDER BY metric must match the
+    // index opclass (cosine here)
+    var results = await db
+        .MockItems.Where(x => EF.Functions.All(x.Id))
+        .Select(x => new
+        {
+            x.Description,
+            Distance = EF.Functions.CosineDistance(x.Embedding, queryEmbedding),
+        })
+        .OrderBy(x => x.Distance)
+        .Take(5)
+        .ToListAsync();
+
+    Console.WriteLine($"\n{new string('=', 70)}");
+    Console.WriteLine($"Similar to: '{seedDescription}'");
+    Console.WriteLine(new string('=', 70));
+
+    for (var i = 0; i < results.Count; i++)
+    {
+        var desc = results[i].Description[..Math.Min(60, results[i].Description.Length)];
+        Console.WriteLine($"  {i + 1}. {desc, -60} (distance: {results[i].Distance:F4})");
+    }
+}

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -13,6 +13,7 @@ examples=(
   Autocomplete
   MoreLikeThis
   HybridRrf
+  VectorSearch
   Rag
 )
 

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -9,11 +9,11 @@ set -euo pipefail
 
 examples=(
   Quickstart
+  VectorSearch
   FacetedSearch
   Autocomplete
   MoreLikeThis
   HybridRrf
-  VectorSearch
   Rag
 )
 

--- a/src/Extensions/ParadeDbDbContextOptionsBuilderExtensions.cs
+++ b/src/Extensions/ParadeDbDbContextOptionsBuilderExtensions.cs
@@ -1,6 +1,10 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using ParadeDB.EntityFrameworkCore.Internal;
+#if NET8_0
+using Npgsql;
+using ParadeDB.EntityFrameworkCore.Internal.Storage;
+#endif
 
 // ReSharper disable SuspiciousTypeConversion.Global
 
@@ -8,10 +12,26 @@ namespace ParadeDB.EntityFrameworkCore.Extensions;
 
 public static class ParadeDbDbContextOptionsBuilderExtensions
 {
+#if NET8_0
+    private static int _vectorResolverRegistered;
+#endif
+
     public static NpgsqlDbContextOptionsBuilder UseParadeDb(
         this NpgsqlDbContextOptionsBuilder optionsBuilder
     )
     {
+#if NET8_0
+        // Npgsql.EntityFrameworkCore.PostgreSQL 8.x has no INpgsqlDataSourceConfigurationPlugin,
+        // so the vector resolver is registered globally instead
+        if (Interlocked.Exchange(ref _vectorResolverRegistered, 1) == 0)
+        {
+#pragma warning disable CS0618
+            NpgsqlConnection.GlobalTypeMapper.AddTypeInfoResolverFactory(
+                new PdbVectorTypeInfoResolverFactory()
+            );
+#pragma warning restore CS0618
+        }
+#endif
         var coreOptionsBuilder = (
             (IRelationalDbContextOptionsBuilderInfrastructure)optionsBuilder
         ).OptionsBuilder;

--- a/src/Extensions/ParadeDbFunctionsExtensions.cs
+++ b/src/Extensions/ParadeDbFunctionsExtensions.cs
@@ -197,6 +197,27 @@ public static class ParadeDbFunctionsExtensions
         throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RangeTerm)));
 
     [DbFunction]
+    public static double L2Distance<TProperty>(
+        this DbFunctions _,
+        TProperty property,
+        float[] queryVector
+    ) => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(L2Distance)));
+
+    [DbFunction]
+    public static double CosineDistance<TProperty>(
+        this DbFunctions _,
+        TProperty property,
+        float[] queryVector
+    ) => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(CosineDistance)));
+
+    [DbFunction]
+    public static double InnerProduct<TProperty>(
+        this DbFunctions _,
+        TProperty property,
+        float[] queryVector
+    ) => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(InnerProduct)));
+
+    [DbFunction]
     public static bool PhrasePrefix<TProperty>(
         this DbFunctions _,
         TProperty property,

--- a/src/Extensions/ParadeDbIndexBuilderExtensions.cs
+++ b/src/Extensions/ParadeDbIndexBuilderExtensions.cs
@@ -27,6 +27,7 @@ public static class ParadeDbIndexBuilderExtensions
         indexBuilder.HasAnnotation(ParadeDbAnnotationNames.IndexFieldKinds, new[] { "property" });
         indexBuilder.HasAnnotation(ParadeDbAnnotationNames.IndexFieldTokenizers, new[] { "" });
         indexBuilder.HasAnnotation(ParadeDbAnnotationNames.IndexFieldAliases, new[] { "" });
+        indexBuilder.HasAnnotation(ParadeDbAnnotationNames.IndexFieldOpclasses, new[] { "" });
 
         return new ParadeDbIndexBuilder<TEntity>(indexBuilder);
     }
@@ -119,6 +120,29 @@ public sealed class ParadeDbIndexBuilder<TEntity>
         return this;
     }
 
+    public ParadeDbIndexBuilder<TEntity> HasField<TProperty>(
+        Expression<Func<TEntity, TProperty>> propertyExpression,
+        VectorMetric metric
+    )
+    {
+        AddField(
+            ParadeDbIndexBuilderExtensions.GetPropertyName(propertyExpression),
+            "property",
+            null,
+            null,
+            metric.ToOpclass()
+        );
+
+        return this;
+    }
+
+    public ParadeDbIndexBuilder<TEntity> HasField(string sql, VectorMetric metric)
+    {
+        AddField(sql, "sql", null, null, metric.ToOpclass());
+
+        return this;
+    }
+
     public ParadeDbIndexBuilder<TEntity> HasFilter(string? sql)
     {
         _indexBuilder.HasFilter(sql);
@@ -143,12 +167,19 @@ public sealed class ParadeDbIndexBuilder<TEntity>
         return this;
     }
 
-    private void AddField(string field, string kind, Tokenizer? tokenizer, string? alias)
+    private void AddField(
+        string field,
+        string kind,
+        Tokenizer? tokenizer,
+        string? alias,
+        string? opclass = null
+    )
     {
         var properties = GetAnnotation(ParadeDbAnnotationNames.IndexFieldProperties);
         var kinds = GetAnnotation(ParadeDbAnnotationNames.IndexFieldKinds);
         var tokenizers = GetAnnotation(ParadeDbAnnotationNames.IndexFieldTokenizers);
         var aliases = GetAnnotation(ParadeDbAnnotationNames.IndexFieldAliases);
+        var opclasses = GetAnnotation(ParadeDbAnnotationNames.IndexFieldOpclasses);
 
         _indexBuilder.HasAnnotation(
             ParadeDbAnnotationNames.IndexFieldProperties,
@@ -166,6 +197,11 @@ public sealed class ParadeDbIndexBuilder<TEntity>
         _indexBuilder.HasAnnotation(
             ParadeDbAnnotationNames.IndexFieldAliases,
             aliases.Append(alias is null ? "" : alias.Replace("'", "''")).ToArray()
+        );
+
+        _indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.IndexFieldOpclasses,
+            opclasses.Append(opclass ?? "").ToArray()
         );
     }
 

--- a/src/Internal/Metadata/ParadeDbAnnotationNames.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationNames.cs
@@ -7,6 +7,7 @@ internal static class ParadeDbAnnotationNames
     public const string IndexFieldKinds = "ParadeDB:IndexFieldKinds";
     public const string IndexFieldTokenizers = "ParadeDB:IndexFieldTokenizers";
     public const string IndexFieldAliases = "ParadeDB:IndexFieldAliases";
+    public const string IndexFieldOpclasses = "ParadeDB:IndexFieldOpclasses";
     public const string IndexSearchTokenizer = "ParadeDB:IndexSearchTokenizer";
     public const string IndexKeyField = "ParadeDB:IndexKeyField";
     public const string IndexFields = "ParadeDB:IndexFields";

--- a/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
@@ -36,15 +36,18 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
             mappedIndex.FindAnnotation(ParadeDbAnnotationNames.IndexFieldTokenizers)!.Value!;
         var fieldAliases = (string[])
             mappedIndex.FindAnnotation(ParadeDbAnnotationNames.IndexFieldAliases)!.Value!;
+        var fieldOpclasses = (string[])
+            mappedIndex.FindAnnotation(ParadeDbAnnotationNames.IndexFieldOpclasses)!.Value!;
 
         if (
             fieldProperties.Length != fieldKinds.Length
             || fieldProperties.Length != fieldTokenizers.Length
             || fieldProperties.Length != fieldAliases.Length
+            || fieldProperties.Length != fieldOpclasses.Length
         )
         {
             throw new InvalidOperationException(
-                "A ParadeDB index must have one kind, tokenizer, and alias entry for each field."
+                "A ParadeDB index must have one kind, tokenizer, alias, and opclass entry for each field."
             );
         }
 
@@ -68,7 +71,8 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
                             fieldKinds[i],
                             storeObject,
                             string.IsNullOrEmpty(fieldTokenizers[i]) ? null : fieldTokenizers[i],
-                            string.IsNullOrEmpty(fieldAliases[i]) ? null : fieldAliases[i]
+                            string.IsNullOrEmpty(fieldAliases[i]) ? null : fieldAliases[i],
+                            string.IsNullOrEmpty(fieldOpclasses[i]) ? null : fieldOpclasses[i]
                         )
                 )
                 .ToArray()
@@ -92,7 +96,8 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
         string kind,
         StoreObjectIdentifier storeObject,
         string? tokenizer,
-        string? alias
+        string? alias,
+        string? opclass
     )
     {
         var sql = kind switch
@@ -101,6 +106,11 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
             "sql" => field,
             _ => throw new InvalidOperationException($"Unknown field kind '{kind}'"),
         };
+
+        if (opclass is not null)
+        {
+            return kind == "property" ? $"{sql} {opclass}" : $"({sql}) {opclass}";
+        }
 
         if (tokenizer is null && alias is null)
         {

--- a/src/Internal/ParadeDbDataSourceConfigurationPlugin.cs
+++ b/src/Internal/ParadeDbDataSourceConfigurationPlugin.cs
@@ -1,0 +1,13 @@
+#if !NET8_0
+using Npgsql;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using ParadeDB.EntityFrameworkCore.Internal.Storage;
+
+namespace ParadeDB.EntityFrameworkCore.Internal;
+
+internal sealed class ParadeDbDataSourceConfigurationPlugin : INpgsqlDataSourceConfigurationPlugin
+{
+    public void Configure(NpgsqlDataSourceBuilder npgsqlDataSourceBuilder) =>
+        npgsqlDataSourceBuilder.AddTypeInfoResolverFactory(new PdbVectorTypeInfoResolverFactory());
+}
+#endif

--- a/src/Internal/ParadeDbOptionsExtension.cs
+++ b/src/Internal/ParadeDbOptionsExtension.cs
@@ -3,10 +3,15 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using ParadeDB.EntityFrameworkCore.Internal.Metadata;
 using ParadeDB.EntityFrameworkCore.Internal.Migrations;
 using ParadeDB.EntityFrameworkCore.Internal.Query;
+using ParadeDB.EntityFrameworkCore.Internal.Storage;
+#if !NET8_0
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+#endif
 
 namespace ParadeDB.EntityFrameworkCore.Internal;
 
@@ -23,6 +28,16 @@ internal sealed class ParadeDbOptionsExtension : IDbContextOptionsExtension
         services.AddScoped<IMigrationsSqlGenerator, ParadeDbMigrationsSqlGenerator>();
         services.AddSingleton<IRelationalAnnotationProvider, ParadeDbAnnotationProvider>();
         services.AddScoped<IMethodCallTranslatorPlugin, ParadeDbMethodCallTranslatorPlugin>();
+        services.AddSingleton<
+            IRelationalTypeMappingSourcePlugin,
+            ParadeDbTypeMappingSourcePlugin
+        >();
+#if !NET8_0
+        new EntityFrameworkNpgsqlServicesBuilder(services).TryAdd<
+            INpgsqlDataSourceConfigurationPlugin,
+            ParadeDbDataSourceConfigurationPlugin
+        >();
+#endif
         services.AddScoped<IMemberTranslatorPlugin, ParadeDbMemberTranslatorPlugin>();
         services.AddSingleton<IConventionSetPlugin, ParadeDbConventionSetPlugin>();
         services.AddSingleton<

--- a/src/Internal/Query/Translator.cs
+++ b/src/Internal/Query/Translator.cs
@@ -105,6 +105,15 @@ internal sealed class Translator : IMethodCallTranslator
                 arguments[1],
                 BuildPhrasePrefix(arguments)
             ),
+            nameof(ParadeDbFunctionsExtensions.L2Distance) => BuildVectorDistance(arguments, "<->"),
+            nameof(ParadeDbFunctionsExtensions.CosineDistance) => BuildVectorDistance(
+                arguments,
+                "<=>"
+            ),
+            nameof(ParadeDbFunctionsExtensions.InnerProduct) => BuildVectorDistance(
+                arguments,
+                "<#>"
+            ),
             nameof(ParadeDbFunctionsExtensions.Snippet) => BuildSnippet(arguments),
             nameof(ParadeDbFunctionsExtensions.Snippets) => BuildSnippets(arguments),
             nameof(ParadeDbFunctionsExtensions.SnippetPositions) => _sqlExpressionFactory.Function(
@@ -247,6 +256,22 @@ internal sealed class Translator : IMethodCallTranslator
             arguments: args,
             argumentsPropagateNullability: new bool[args.Count],
             returnType: typeof(bool)
+        );
+    }
+
+    private PgUnknownBinaryExpression BuildVectorDistance(
+        IReadOnlyList<SqlExpression> arguments,
+        string binaryOperator
+    )
+    {
+        var vectorMapping = arguments[1].TypeMapping ?? PdbVectorTypeMapping.Default;
+
+        return new PgUnknownBinaryExpression(
+            _sqlExpressionFactory.ApplyTypeMapping(arguments[1], vectorMapping),
+            _sqlExpressionFactory.ApplyTypeMapping(arguments[2], vectorMapping),
+            binaryOperator,
+            typeof(double),
+            PdbTypeMappings.Double
         );
     }
 

--- a/src/Internal/Storage/ParadeDbTypeMappingSourcePlugin.cs
+++ b/src/Internal/Storage/ParadeDbTypeMappingSourcePlugin.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace ParadeDB.EntityFrameworkCore.Internal.Storage;
+
+internal sealed class ParadeDbTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
+{
+    public RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
+    {
+        if (
+            !string.Equals(
+                mappingInfo.StoreTypeNameBase,
+                "vector",
+                StringComparison.OrdinalIgnoreCase
+            ) || (mappingInfo.ClrType is not null && mappingInfo.ClrType != typeof(float[]))
+        )
+        {
+            return null;
+        }
+
+        return new PdbVectorTypeMapping(mappingInfo.StoreTypeName!);
+    }
+}

--- a/src/Internal/Storage/PdbTypeMappings.cs
+++ b/src/Internal/Storage/PdbTypeMappings.cs
@@ -9,6 +9,8 @@ internal static class PdbTypeMappings
 {
     public static readonly RelationalTypeMapping Boolean = new NpgsqlBoolTypeMapping();
 
+    public static readonly RelationalTypeMapping Double = new NpgsqlDoubleTypeMapping();
+
     public static readonly RelationalTypeMapping Text = new NpgsqlStringTypeMapping(
         "text",
         NpgsqlDbType.Text

--- a/src/Internal/Storage/PdbVectorConverter.cs
+++ b/src/Internal/Storage/PdbVectorConverter.cs
@@ -1,0 +1,106 @@
+using Npgsql.Internal;
+
+namespace ParadeDB.EntityFrameworkCore.Internal.Storage;
+
+internal sealed class PdbVectorConverter : PgStreamingConverter<float[]>
+{
+    public override float[] Read(PgReader reader)
+    {
+        if (reader.ShouldBuffer(2 * sizeof(ushort)))
+        {
+            reader.Buffer(2 * sizeof(ushort));
+        }
+
+        var dimensions = reader.ReadUInt16();
+        reader.ReadUInt16();
+
+        var vector = new float[dimensions];
+        for (var i = 0; i < dimensions; i++)
+        {
+            if (reader.ShouldBuffer(sizeof(float)))
+            {
+                reader.Buffer(sizeof(float));
+            }
+
+            vector[i] = reader.ReadFloat();
+        }
+
+        return vector;
+    }
+
+    public override async ValueTask<float[]> ReadAsync(
+        PgReader reader,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (reader.ShouldBuffer(2 * sizeof(ushort)))
+        {
+            await reader.BufferAsync(2 * sizeof(ushort), cancellationToken).ConfigureAwait(false);
+        }
+
+        var dimensions = reader.ReadUInt16();
+        reader.ReadUInt16();
+
+        var vector = new float[dimensions];
+        for (var i = 0; i < dimensions; i++)
+        {
+            if (reader.ShouldBuffer(sizeof(float)))
+            {
+                await reader.BufferAsync(sizeof(float), cancellationToken).ConfigureAwait(false);
+            }
+
+            vector[i] = reader.ReadFloat();
+        }
+
+        return vector;
+    }
+
+    public override Size GetSize(SizeContext context, float[] value, ref object? writeState) =>
+        2 * sizeof(ushort) + sizeof(float) * value.Length;
+
+    public override void Write(PgWriter writer, float[] value)
+    {
+        if (writer.ShouldFlush(2 * sizeof(ushort)))
+        {
+            writer.Flush();
+        }
+
+        writer.WriteUInt16(Convert.ToUInt16(value.Length));
+        writer.WriteUInt16(0);
+
+        foreach (var element in value)
+        {
+            if (writer.ShouldFlush(sizeof(float)))
+            {
+                writer.Flush();
+            }
+
+            writer.WriteFloat(element);
+        }
+    }
+
+    public override async ValueTask WriteAsync(
+        PgWriter writer,
+        float[] value,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (writer.ShouldFlush(2 * sizeof(ushort)))
+        {
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        writer.WriteUInt16(Convert.ToUInt16(value.Length));
+        writer.WriteUInt16(0);
+
+        foreach (var element in value)
+        {
+            if (writer.ShouldFlush(sizeof(float)))
+            {
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            writer.WriteFloat(element);
+        }
+    }
+}

--- a/src/Internal/Storage/PdbVectorTypeInfoResolverFactory.cs
+++ b/src/Internal/Storage/PdbVectorTypeInfoResolverFactory.cs
@@ -1,0 +1,36 @@
+using Npgsql.Internal;
+using Npgsql.Internal.Postgres;
+
+namespace ParadeDB.EntityFrameworkCore.Internal.Storage;
+
+internal sealed class PdbVectorTypeInfoResolverFactory : PgTypeInfoResolverFactory
+{
+    public override IPgTypeInfoResolver CreateResolver() => new Resolver();
+
+    public override IPgTypeInfoResolver? CreateArrayResolver() => null;
+
+    private sealed class Resolver : IPgTypeInfoResolver
+    {
+        private TypeInfoMappingCollection? _mappings;
+
+        private TypeInfoMappingCollection Mappings => _mappings ??= AddMappings(new());
+
+        public PgTypeInfo? GetTypeInfo(
+            Type? type,
+            DataTypeName? dataTypeName,
+            PgSerializerOptions options
+        ) => Mappings.Find(type, dataTypeName, options);
+
+        private static TypeInfoMappingCollection AddMappings(TypeInfoMappingCollection mappings)
+        {
+            mappings.AddType<float[]>(
+                "vector",
+                static (options, mapping, _) =>
+                    mapping.CreateInfo(options, new PdbVectorConverter()),
+                isDefault: true
+            );
+
+            return mappings;
+        }
+    }
+}

--- a/src/Internal/Storage/PdbVectorTypeMapping.cs
+++ b/src/Internal/Storage/PdbVectorTypeMapping.cs
@@ -1,0 +1,40 @@
+using System.Data.Common;
+using System.Globalization;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
+
+namespace ParadeDB.EntityFrameworkCore.Internal.Storage;
+
+internal sealed class PdbVectorTypeMapping : RelationalTypeMapping
+{
+    public static readonly PdbVectorTypeMapping Default = new("vector");
+
+    public PdbVectorTypeMapping(string storeType)
+        : base(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(
+                    typeof(float[]),
+                    converter: null,
+                    comparer: new ValueComparer<float[]>(
+                        (a, b) => a == null ? b == null : b != null && a.SequenceEqual(b),
+                        v => v.Aggregate(17, (hash, value) => HashCode.Combine(hash, value)),
+                        v => v.ToArray()
+                    )
+                ),
+                storeType
+            )
+        ) { }
+
+    private PdbVectorTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters) { }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters) =>
+        new PdbVectorTypeMapping(parameters);
+
+    protected override void ConfigureParameter(DbParameter parameter) =>
+        ((NpgsqlParameter)parameter).DataTypeName = "vector";
+
+    protected override string GenerateNonNullSqlLiteral(object value) =>
+        $"'[{string.Join(",", ((float[])value).Select(v => v.ToString(CultureInfo.InvariantCulture)))}]'";
+}

--- a/src/ParadeDB.EntityFrameworkCore.csproj
+++ b/src/ParadeDB.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NoWarn>$(NoWarn);EF1001</NoWarn>
+    <NoWarn>$(NoWarn);EF1001;NPG9001</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/VectorMetric.cs
+++ b/src/VectorMetric.cs
@@ -1,0 +1,20 @@
+namespace ParadeDB.EntityFrameworkCore;
+
+public enum VectorMetric
+{
+    L2,
+    Cosine,
+    InnerProduct,
+}
+
+internal static class VectorMetricExtensions
+{
+    public static string ToOpclass(this VectorMetric metric) =>
+        metric switch
+        {
+            VectorMetric.L2 => "vector_l2_ops",
+            VectorMetric.Cosine => "vector_cosine_ops",
+            VectorMetric.InnerProduct => "vector_ip_ops",
+            _ => throw new ArgumentOutOfRangeException(nameof(metric)),
+        };
+}

--- a/tests/DiagnosticsTests.cs
+++ b/tests/DiagnosticsTests.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
+using ParadeDB.EntityFrameworkCore.Extensions;
 using ParadeDB.EntityFrameworkCore.Tests.Persistence;
 using Shouldly;
 
@@ -9,7 +10,7 @@ public sealed class DiagnosticsTests
 {
     private static readonly DbContextOptions<TestDbContext> Options =
         new DbContextOptionsBuilder<TestDbContext>()
-            .UseNpgsql("Host=localhost;Database=paradedb_tests")
+            .UseNpgsql("Host=localhost;Database=paradedb_tests", o => o.UseParadeDb())
             .Options;
 
     private static void AssertSql(IQueryable query, string expected) =>

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -322,6 +322,67 @@ public sealed class IndexingTest : TestBase
         await context.Database.ExecuteSqlRawAsync(sql);
     }
 
+    private sealed class VectorIndexContext(DbContextOptions<VectorIndexContext> options)
+        : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("indexing_items");
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Description).HasColumnName("description");
+                entity
+                    .Property(e => e.EmbeddingL2)
+                    .HasColumnName("embedding_l2")
+                    .HasColumnType("vector(3)");
+                entity
+                    .Property(e => e.EmbeddingCosine)
+                    .HasColumnName("embedding_cosine")
+                    .HasColumnType("vector(3)");
+                entity
+                    .Property(e => e.EmbeddingIp)
+                    .HasColumnName("embedding_ip")
+                    .HasColumnType("vector(3)");
+
+                entity
+                    .HasParadeDbIndex("indexing_items_idx", e => e.Id)
+                    .HasField(e => e.Description)
+                    .HasField(e => e.EmbeddingL2, VectorMetric.L2)
+                    .HasField(e => e.EmbeddingCosine, VectorMetric.Cosine)
+                    .HasField("embedding_ip", VectorMetric.InnerProduct);
+            });
+        }
+    }
+
+    [Test]
+    public async Task ParadeDbIndex_WithVectorFields()
+    {
+        await using var context = DbFixture.CreateContext();
+        await context.Database.OpenConnectionAsync();
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            CREATE TEMP TABLE indexing_items (
+                id int PRIMARY KEY,
+                description text,
+                embedding_l2 vector(3),
+                embedding_cosine vector(3),
+                embedding_ip vector(3)
+            );
+            """
+        );
+
+        var sql = GenerateCreateIndexSql<VectorIndexContext, IndexingItem>();
+
+        sql.ShouldBe(
+            """
+            CREATE INDEX indexing_items_idx ON indexing_items USING paradedb (id, description, embedding_l2 vector_l2_ops, embedding_cosine vector_cosine_ops, (embedding_ip) vector_ip_ops) WITH (key_field = 'id');
+
+            """
+        );
+        await context.Database.ExecuteSqlRawAsync(sql);
+    }
+
     private static string GenerateCreateIndexSql<TContext, TEntity>()
         where TContext : DbContext
     {
@@ -380,5 +441,8 @@ public sealed class IndexingTest : TestBase
         public string[] Tags { get; set; } = [];
         public JsonDocument? Metadata { get; set; }
         public int Rating { get; set; }
+        public float[]? EmbeddingL2 { get; set; }
+        public float[]? EmbeddingCosine { get; set; }
+        public float[]? EmbeddingIp { get; set; }
     }
 }

--- a/tests/Persistence/MockItem.cs
+++ b/tests/Persistence/MockItem.cs
@@ -15,4 +15,5 @@ public sealed class MockItem
     public DateOnly LastUpdatedDate { get; set; }
     public TimeOnly LatestAvailableTime { get; set; }
     public NpgsqlRange<int>? WeightRange { get; set; }
+    public float[]? Embedding { get; set; }
 }

--- a/tests/Persistence/TestDbContext.cs
+++ b/tests/Persistence/TestDbContext.cs
@@ -13,6 +13,10 @@ public sealed class TestDbContext : DbContext
     {
         base.OnModelCreating(modelBuilder);
 
-        modelBuilder.Entity<MockItem>().HasKey(p => p.Id);
+        modelBuilder.Entity<MockItem>(entity =>
+        {
+            entity.HasKey(p => p.Id);
+            entity.Property(p => p.Embedding).HasColumnType("vector(8)");
+        });
     }
 }

--- a/tests/QueryTests.cs
+++ b/tests/QueryTests.cs
@@ -1,7 +1,9 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NpgsqlTypes;
 using ParadeDB.EntityFrameworkCore.Extensions;
+using ParadeDB.EntityFrameworkCore.Tests.Persistence;
 using Shouldly;
 
 namespace ParadeDB.EntityFrameworkCore.Tests;
@@ -26,7 +28,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.MatchAll(p.Description, "these"));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& 'these'
             """;
@@ -45,7 +47,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& lower(m.category)
             """;
@@ -64,7 +66,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& ARRAY['these','shoes']::text[]
             """;
@@ -84,7 +86,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @terms={ 'these', 'shoes' } (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& @terms
             """;
@@ -103,7 +105,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& 'these'::pdb.fuzzy(2)
             """;
@@ -122,7 +124,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& ARRAY['these','shoes']::text[]::pdb.fuzzy(2)
             """;
@@ -144,7 +146,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @terms={ 'these', 'shoes' } (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& @terms::pdb.fuzzy(2)
             """;
@@ -163,7 +165,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& 'these'::pdb.boost(2.3)
             """;
@@ -182,7 +184,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& ARRAY['these','shoes']::text[]::pdb.boost(2.3)
             """;
@@ -204,7 +206,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @terms={ 'these', 'shoes' } (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& @terms::pdb.boost(2.3)
             """;
@@ -223,7 +225,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& 'these'::pdb.const(20.3)
             """;
@@ -242,7 +244,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& ARRAY['these','shoes']::text[]::pdb.const(20.3)
             """;
@@ -264,7 +266,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @terms={ 'these', 'shoes' } (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& @terms::pdb.const(20.3)
             """;
@@ -283,7 +285,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description &&& 'these'::pdb.fuzzy(2)::pdb.boost(2.3)
             """;
@@ -398,7 +400,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.MatchAny(p.Description, "these"));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ||| 'these'
             """;
@@ -417,7 +419,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ||| ARRAY['these','shoes']::text[]
             """;
@@ -437,7 +439,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @terms={ 'these', 'shoes' } (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ||| @terms
             """;
@@ -456,7 +458,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ||| 'these'::pdb.const(20.3)
             """;
@@ -473,7 +475,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.Phrase(p.Description, "with"));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ### 'with'
             """;
@@ -492,7 +494,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ### ARRAY['these','shoes']::text[]
             """;
@@ -512,7 +514,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @terms={ 'these', 'shoes' } (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ### @terms
             """;
@@ -531,7 +533,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ### 'with'::pdb.boost(2.5)
             """;
@@ -550,7 +552,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ### 'with'::pdb.slop(2)
             """;
@@ -569,7 +571,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ### ARRAY['these','shoes']::text[]::pdb.slop(2)
             """;
@@ -591,7 +593,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @terms={ 'these', 'shoes' } (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description ### @terms::pdb.slop(2)
             """;
@@ -610,7 +612,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ (('sleek' ## 1) ## 'shoes')
             """;
@@ -632,7 +634,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ (('sleek' ##> 1) ##> 'shoes')
             """;
@@ -658,7 +660,7 @@ public sealed class QueryTests : TestBase
             -- @left='sleek'
             -- @distance='1'
             -- @right='shoes'
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ ((@left ## @distance) ## @right)
             """;
@@ -677,7 +679,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ ((pdb.prox_regex('sl.*') ## 1) ## 'shoes')
             """;
@@ -699,7 +701,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @pattern='sl.*'
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ ((pdb.prox_regex(@pattern) ## 1) ## 'shoes')
             """;
@@ -721,7 +723,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ ((pdb.prox_regex('sl.*', 100) ## 1) ## 'shoes')
             """;
@@ -743,7 +745,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ ((pdb.prox_array('sleek', 'white') ## 1) ## 'shoes')
             """;
@@ -767,7 +769,7 @@ public sealed class QueryTests : TestBase
         var sql = """
             -- @t1='sleek'
             -- @t2='white'
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ ((pdb.prox_array(@t1, @t2) ## 1) ## 'shoes')
             """;
@@ -790,7 +792,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ ((pdb.prox_array(pdb.prox_regex('sl.*'), pdb.prox_array('white')) ## 1) ## 'shoes')
             """;
@@ -812,7 +814,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description @@@ (((('sleek' ## 1) ## 'running') ## 2) ## 'shoes')
             """;
@@ -879,7 +881,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.All(p.Id));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.id @@@ pdb.all()
             """;
@@ -896,7 +898,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.Exists(p.Id));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.id @@@ pdb.exists()
             """;
@@ -913,7 +915,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.RangeTerm(p.WeightRange, 1));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.weight_range @@@ pdb.range_term(1)
             """;
@@ -935,7 +937,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @range='(10,12]' (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.weight_range @@@ pdb.range_term(@range, 'Intersects')
             """;
@@ -1216,7 +1218,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.Term(p.Description, "rich"));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description === 'rich'
             """;
@@ -1235,7 +1237,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description === ARRAY['rich','cream']::text[]
             """;
@@ -1255,7 +1257,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @terms={ 'rich', 'cream' } (DbType = Object)
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description === @terms
             """;
@@ -1274,7 +1276,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description === 'rich'::pdb.fuzzy(2)
             """;
@@ -1293,7 +1295,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description === 'rich'::pdb.fuzzy(2)
             """;
@@ -1306,7 +1308,7 @@ public sealed class QueryTests : TestBase
         );
 
         sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description === 'rich'::pdb.fuzzy(2, t)
             """;
@@ -1319,7 +1321,7 @@ public sealed class QueryTests : TestBase
         );
 
         sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description === 'rich'::pdb.fuzzy(2, f, t)
             """;
@@ -1332,7 +1334,7 @@ public sealed class QueryTests : TestBase
         );
 
         sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.description === 'rich'::pdb.fuzzy(2, t, t)
             """;
@@ -1396,7 +1398,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.MoreLikeThisId(p.Id, 5));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.id @@@ pdb.more_like_this(5)
             """;
@@ -1416,7 +1418,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @id='5'
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.id @@@ pdb.more_like_this(@id)
             """;
@@ -1435,7 +1437,7 @@ public sealed class QueryTests : TestBase
         );
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.id @@@ pdb.more_like_this('{"description":"running shoes"}')
             """;
@@ -1455,7 +1457,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @document='{"description":"running shoes"}'
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.id @@@ pdb.more_like_this(@document)
             """;
@@ -1484,7 +1486,7 @@ public sealed class QueryTests : TestBase
         var query = context.MockItems.Where(p => EF.Functions.MoreLikeThisId(p.Id, 5, options));
 
         var sql = """
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.id @@@ pdb.more_like_this(5, ARRAY['description','category']::text[], min_term_frequency => 2, min_doc_frequency => 3, max_doc_frequency => 100, max_query_terms => 12, min_word_length => 3, max_word_length => 20, stopwords => ARRAY['the','and']::text[])
             """;
@@ -1523,7 +1525,7 @@ public sealed class QueryTests : TestBase
 
         var sql = """
             -- @id='5'
-            SELECT m.id, m.category, m.created_at, m.description, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
+            SELECT m.id, m.category, m.created_at, m.description, m.embedding, m.in_stock, m.last_updated_date, m.latest_available_time, m.metadata, m.rating, m.weight_range
             FROM mock_items AS m
             WHERE m.id @@@ pdb.more_like_this(@id, ARRAY['description','category']::text[], min_term_frequency => 2, min_doc_frequency => 3, max_doc_frequency => 100, max_query_terms => 12, min_word_length => 3, max_word_length => 20, stopwords => ARRAY['the','and']::text[])
             """;
@@ -1910,5 +1912,224 @@ public sealed class QueryTests : TestBase
 
         AssertSql(query, sql);
         await query.ToListAsync();
+    }
+
+    private static async Task<(int Id, float[] Embedding)> SeedItemAsync(
+        TestDbContext context,
+        string description
+    )
+    {
+        var seed = await context
+            .MockItems.Where(m => m.Description == description)
+            .Select(m => new { m.Id, m.Embedding })
+            .SingleAsync();
+
+        return (seed.Id, seed.Embedding!);
+    }
+
+    private static async Task<List<int>> ExpectedTopKAsync(
+        TestDbContext context,
+        float[] queryVector,
+        Func<float[], float[], double> distance,
+        int k
+    )
+    {
+        var items = await context.MockItems.Select(m => new { m.Id, m.Embedding }).ToListAsync();
+
+        return items
+            .OrderBy(x => distance(x.Embedding!, queryVector))
+            .Take(k)
+            .Select(x => x.Id)
+            .ToList();
+    }
+
+    private static double L2Distance(float[] a, float[] b) =>
+        Math.Sqrt(a.Zip(b, (x, y) => (double)(x - y) * (x - y)).Sum());
+
+    private static double CosineDistance(float[] a, float[] b)
+    {
+        var dot = a.Zip(b, (x, y) => (double)x * y).Sum();
+        var normA = Math.Sqrt(a.Sum(x => (double)x * x));
+        var normB = Math.Sqrt(b.Sum(x => (double)x * x));
+
+        return 1 - dot / (normA * normB);
+    }
+
+    private static double InnerProduct(float[] a, float[] b) =>
+        -a.Zip(b, (x, y) => (double)x * y).Sum();
+
+    private static string VectorParam(float[] vector) =>
+        "{ "
+        + string.Join(
+            ", ",
+            vector.Take(5).Select(v => $"'{v.ToString(CultureInfo.InvariantCulture)}'")
+        )
+        + (vector.Length > 5 ? ", ..." : "")
+        + " }";
+
+    [Test]
+    public async Task Vector_RoundTrip()
+    {
+        await using var context = DbFixture.CreateContext();
+        await using var transaction = await context.Database.BeginTransactionAsync();
+
+        var maxId = await context.MockItems.MaxAsync(m => m.Id);
+        float[] embedding = [1, 0, 0, 0, 0.5f, 0, 0, -1];
+
+        context.MockItems.AddRange(
+            new MockItem
+            {
+                Id = maxId + 1,
+                Description = "Embedded item",
+                Rating = 3,
+                Embedding = embedding,
+            },
+            new MockItem
+            {
+                Id = maxId + 2,
+                Description = "Unembedded item",
+                Rating = 3,
+                Embedding = null,
+            }
+        );
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        var items = await context
+            .MockItems.Where(m => m.Id > maxId)
+            .OrderBy(m => m.Id)
+            .ToListAsync();
+
+        items.Count.ShouldBe(2);
+        items[0].Embedding.ShouldBe(embedding);
+        items[1].Embedding.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task L2Distance_TopK()
+    {
+        await using var context = DbFixture.CreateContext();
+
+        var (seedId, queryVector) = await SeedItemAsync(context, "Ergonomic metal keyboard");
+
+        var query = context
+            .MockItems.OrderBy(m => EF.Functions.L2Distance(m.Embedding, queryVector))
+            .Select(m => m.Id)
+            .Take(3);
+
+        var sql = $"""
+            -- @queryVector={VectorParam(queryVector)} (DbType = Object)
+            -- @p='3'
+            SELECT m.id
+            FROM mock_items AS m
+            ORDER BY m.embedding <-> @queryVector
+            LIMIT @p
+            """;
+
+        AssertSql(query, sql);
+
+        var results = await query.ToListAsync();
+        results.ShouldBe(await ExpectedTopKAsync(context, queryVector, L2Distance, 3));
+        results[0].ShouldBe(seedId);
+    }
+
+    [Test]
+    public async Task CosineDistance_TopK()
+    {
+        await using var context = DbFixture.CreateContext();
+
+        var (seedId, queryVector) = await SeedItemAsync(context, "Sleek running shoes");
+
+        var query = context
+            .MockItems.OrderBy(m => EF.Functions.CosineDistance(m.Embedding, queryVector))
+            .Select(m => m.Id)
+            .Take(3);
+
+        var sql = $"""
+            -- @queryVector={VectorParam(queryVector)} (DbType = Object)
+            -- @p='3'
+            SELECT m.id
+            FROM mock_items AS m
+            ORDER BY m.embedding <=> @queryVector
+            LIMIT @p
+            """;
+
+        AssertSql(query, sql);
+
+        var results = await query.ToListAsync();
+        results.ShouldBe(await ExpectedTopKAsync(context, queryVector, CosineDistance, 3));
+        results[0].ShouldBe(seedId);
+    }
+
+    [Test]
+    public async Task InnerProduct_TopK()
+    {
+        await using var context = DbFixture.CreateContext();
+
+        var (_, queryVector) = await SeedItemAsync(context, "Innovative wireless earbuds");
+
+        var query = context
+            .MockItems.OrderBy(m => EF.Functions.InnerProduct(m.Embedding, queryVector))
+            .Select(m => m.Id)
+            .Take(3);
+
+        var sql = $"""
+            -- @queryVector={VectorParam(queryVector)} (DbType = Object)
+            -- @p='3'
+            SELECT m.id
+            FROM mock_items AS m
+            ORDER BY m.embedding <#> @queryVector
+            LIMIT @p
+            """;
+
+        AssertSql(query, sql);
+
+        (await query.ToListAsync()).ShouldBe(
+            await ExpectedTopKAsync(context, queryVector, InnerProduct, 3)
+        );
+    }
+
+    [Test]
+    public async Task VectorSearch_WithMatchAllPredicate()
+    {
+        await using var context = DbFixture.CreateContext();
+
+        float[] queryVector = [1, 0, 0, 0, 0, 0, 0, 0];
+
+        var query = context
+            .MockItems.Where(m => EF.Functions.All(m.Id))
+            .OrderBy(m => EF.Functions.CosineDistance(m.Embedding, queryVector))
+            .Select(m => m.Id)
+            .Take(2);
+
+        var sql = """
+            -- @queryVector={ '1', '0', '0', '0', '0', ... } (DbType = Object)
+            -- @p='2'
+            SELECT m.id
+            FROM mock_items AS m
+            WHERE m.id @@@ pdb.all()
+            ORDER BY m.embedding <=> @queryVector
+            LIMIT @p
+            """;
+
+        AssertSql(query, sql);
+    }
+
+    [Test]
+    public async Task VectorSearch_WithParadeDbIndex()
+    {
+        await using var context = DbFixture.CreateContext();
+
+        var (seedId, queryVector) = await SeedItemAsync(context, "Sleek running shoes");
+
+        var results = await context
+            .MockItems.Where(m => EF.Functions.All(m.Id))
+            .OrderBy(m => EF.Functions.CosineDistance(m.Embedding, queryVector))
+            .Select(m => m.Id)
+            .Take(3)
+            .ToListAsync();
+
+        results.ShouldBe(await ExpectedTopKAsync(context, queryVector, CosineDistance, 3));
+        results[0].ShouldBe(seedId);
     }
 }


### PR DESCRIPTION
## What

Implements paradedb/paradedb#5685: native vector search support with no Pgvector/Pgvector.EntityFrameworkCore dependency.

- `HasVectorType(n)` property mapping for pgvector `vector(n)` on `float[]`, including migration DDL and round-trip serialization via a minimal Npgsql binary converter (plugin-registered on EF9/10, GlobalTypeMapper on EF8)
- `EF.Functions.L2Distance/CosineDistance/InnerProduct` translating to `<->`/`<=>`/`<#>` with parameterized query vectors
- `Bm25IndexBuilder.HasField(x => x.Embedding, VectorMetric.Cosine)` emitting vector opclasses inside `USING bm25` DDL
- HybridRrf example migrated off pgvector-dotnet; new VectorSearch example; vector-in-bm25 integration tests capability-gated until released

## Why

ParadeDB indexes pgvector columns inside the bm25 index, so users should get the full query surface from this package alone.

## Tests

net8.0/net9.0/net10.0 each: 114 passed, 2 skipped (capability-gated) against a live Testcontainer. csharpier/api-coverage/codespell/markdownlint clean.

Note: on EF9/10 the type converter auto-registers when the provider builds the data source; users passing a pre-built `NpgsqlDataSource` need manual setup (same caveat as pgvector-dotnet).