### PR TITLE
fix: Quote uppercase column names in index creation

### DIFF
--- a/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
@@ -1,14 +1,23 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 
 namespace ParadeDB.EntityFrameworkCore.Internal.Metadata;
 
 internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
 {
-    public ParadeDbAnnotationProvider(RelationalAnnotationProviderDependencies dependencies)
-        : base(dependencies) { }
+    private readonly ISqlGenerationHelper _sqlGenerationHelper;
+
+    public ParadeDbAnnotationProvider(
+        RelationalAnnotationProviderDependencies dependencies,
+        ISqlGenerationHelper sqlGenerationHelper
+    )
+        : base(dependencies)
+    {
+        _sqlGenerationHelper = sqlGenerationHelper;
+    }
 
     public override IEnumerable<IAnnotation> For(ITableIndex index, bool designTime)
     {
@@ -90,7 +99,7 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
         }
     }
 
-    private static string RenderField(
+    private string RenderField(
         IReadOnlyEntityType entityType,
         string field,
         string kind,
@@ -102,7 +111,9 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
     {
         var sql = kind switch
         {
-            "property" => entityType.FindProperty(field)!.GetColumnName(storeObject)!,
+            "property" => _sqlGenerationHelper.DelimitIdentifier(
+                entityType.FindProperty(field)!.GetColumnName(storeObject)!
+            ),
             "sql" => field,
             _ => throw new InvalidOperationException($"Unknown field kind '{kind}'"),
         };

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -172,7 +172,9 @@ public sealed class IndexingTest : TestBase
                 entity.ToTable("Items");
                 entity
                     .HasParadeDbIndex("indexing_items_idx", e => e.Id)
-                    .HasField(e => e.Description);
+                    .HasField(e => e.Description, Tokenizer.Literal())
+                    .HasField(e => e.Rating, new FieldAlias("rating_alias"))
+                    .HasField(e => e.EmbeddingL2, VectorMetric.L2);
             });
         }
     }
@@ -184,7 +186,7 @@ public sealed class IndexingTest : TestBase
 
         sql.ShouldBe(
             """
-            CREATE INDEX indexing_items_idx ON "Items" USING paradedb ("Id", "Description") WITH (key_field = 'Id');
+            CREATE INDEX indexing_items_idx ON "Items" USING paradedb ("Id", ("Description"::pdb.literal), ("Rating"::pdb.alias('rating_alias')), "EmbeddingL2" vector_l2_ops) WITH (key_field = 'Id');
 
             """
         );

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -162,6 +162,34 @@ public sealed class IndexingTest : TestBase
         await context.Database.ExecuteSqlRawAsync(sql);
     }
 
+    private sealed class PascalCaseIndexContext(DbContextOptions<PascalCaseIndexContext> options)
+        : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("Items");
+                entity
+                    .HasParadeDbIndex("indexing_items_idx", e => e.Id)
+                    .HasField(e => e.Description);
+            });
+        }
+    }
+
+    [Test]
+    public void ParadeDbIndex_QuotesPascalCaseColumnNames()
+    {
+        var sql = GenerateCreateIndexSql<PascalCaseIndexContext, IndexingItem>();
+
+        sql.ShouldBe(
+            """
+            CREATE INDEX indexing_items_idx ON "Items" USING paradedb ("Id", "Description") WITH (key_field = 'Id');
+
+            """
+        );
+    }
+
     private sealed class ArrayExpressionIndexContext(
         DbContextOptions<ArrayExpressionIndexContext> options
     ) : DbContext(options)


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #94

## What

Uppercase Postgres columns need to be quoted to be interpreted as uppercase. This PR adds support for this.

## Why

## How

## Tests
