### PR TITLE
feat: support vector index build options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- Vector index build options on ParadeDB indexes: `HasCentroidRatio`,
+  `HasTrainingSamplesPerCentroid`, and `HasClusterReplication` emit the
+  `centroid_ratio`, `training_samples_per_centroid`, and `cluster_replication`
+  `WITH` options in index DDL.
+
 ## [0.2.0] - 2026-08-04
 
 ### Added

--- a/src/Extensions/ParadeDbIndexBuilderExtensions.cs
+++ b/src/Extensions/ParadeDbIndexBuilderExtensions.cs
@@ -167,6 +167,35 @@ public sealed class ParadeDbIndexBuilder<TEntity>
         return this;
     }
 
+    public ParadeDbIndexBuilder<TEntity> HasCentroidRatio(double centroidRatio)
+    {
+        _indexBuilder.HasAnnotation(ParadeDbAnnotationNames.IndexCentroidRatio, centroidRatio);
+
+        return this;
+    }
+
+    public ParadeDbIndexBuilder<TEntity> HasTrainingSamplesPerCentroid(
+        int trainingSamplesPerCentroid
+    )
+    {
+        _indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.IndexTrainingSamplesPerCentroid,
+            trainingSamplesPerCentroid
+        );
+
+        return this;
+    }
+
+    public ParadeDbIndexBuilder<TEntity> HasClusterReplication(int clusterReplication)
+    {
+        _indexBuilder.HasAnnotation(
+            ParadeDbAnnotationNames.IndexClusterReplication,
+            clusterReplication
+        );
+
+        return this;
+    }
+
     private void AddField(
         string field,
         string kind,

--- a/src/Internal/Metadata/ParadeDbAnnotationNames.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationNames.cs
@@ -11,4 +11,8 @@ internal static class ParadeDbAnnotationNames
     public const string IndexSearchTokenizer = "ParadeDB:IndexSearchTokenizer";
     public const string IndexKeyField = "ParadeDB:IndexKeyField";
     public const string IndexFields = "ParadeDB:IndexFields";
+    public const string IndexCentroidRatio = "ParadeDB:IndexCentroidRatio";
+    public const string IndexTrainingSamplesPerCentroid =
+        "ParadeDB:IndexTrainingSamplesPerCentroid";
+    public const string IndexClusterReplication = "ParadeDB:IndexClusterReplication";
 }

--- a/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
+++ b/src/Internal/Metadata/ParadeDbAnnotationProvider.cs
@@ -97,6 +97,20 @@ internal sealed class ParadeDbAnnotationProvider : NpgsqlAnnotationProvider
                 searchTokenizer
             );
         }
+
+        string[] vectorOptionNames =
+        [
+            ParadeDbAnnotationNames.IndexCentroidRatio,
+            ParadeDbAnnotationNames.IndexTrainingSamplesPerCentroid,
+            ParadeDbAnnotationNames.IndexClusterReplication,
+        ];
+        foreach (var name in vectorOptionNames)
+        {
+            if (mappedIndex.FindAnnotation(name)?.Value is { } value)
+            {
+                yield return new Annotation(name, value);
+            }
+        }
     }
 
     private string RenderField(

--- a/src/Internal/Migrations/ParadeDbMigrationsSqlGenerator.cs
+++ b/src/Internal/Migrations/ParadeDbMigrationsSqlGenerator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
@@ -57,6 +58,36 @@ internal sealed class ParadeDbMigrationsSqlGenerator : NpgsqlMigrationsSqlGenera
             builder
                 .Append(", search_tokenizer = ")
                 .Append(stringMapping.GenerateSqlLiteral(searchTokenizer));
+        }
+
+        if (
+            operation.FindAnnotation(ParadeDbAnnotationNames.IndexCentroidRatio)?.Value
+            is double centroidRatio
+        )
+        {
+            builder
+                .Append(", centroid_ratio = ")
+                .Append(centroidRatio.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (
+            operation.FindAnnotation(ParadeDbAnnotationNames.IndexTrainingSamplesPerCentroid)?.Value
+            is int trainingSamplesPerCentroid
+        )
+        {
+            builder
+                .Append(", training_samples_per_centroid = ")
+                .Append(trainingSamplesPerCentroid.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (
+            operation.FindAnnotation(ParadeDbAnnotationNames.IndexClusterReplication)?.Value
+            is int clusterReplication
+        )
+        {
+            builder
+                .Append(", cluster_replication = ")
+                .Append(clusterReplication.ToString(CultureInfo.InvariantCulture));
         }
 
         builder.Append(")");

--- a/tests/IndexingTest.cs
+++ b/tests/IndexingTest.cs
@@ -413,6 +413,79 @@ public sealed class IndexingTest : TestBase
         await context.Database.ExecuteSqlRawAsync(sql);
     }
 
+    private sealed class VectorIndexOptionsContext(
+        DbContextOptions<VectorIndexOptionsContext> options
+    ) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("indexing_items");
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Description).HasColumnName("description");
+                entity
+                    .Property(e => e.EmbeddingCosine)
+                    .HasColumnName("embedding_cosine")
+                    .HasColumnType("vector(3)");
+
+                entity
+                    .HasParadeDbIndex("indexing_items_idx", e => e.Id)
+                    .HasField(e => e.Description)
+                    .HasField(e => e.EmbeddingCosine, VectorMetric.Cosine)
+                    .HasCentroidRatio(0.05)
+                    .HasTrainingSamplesPerCentroid(64)
+                    .HasClusterReplication(2);
+            });
+        }
+    }
+
+    [Test]
+    public void ParadeDbIndex_WithVectorIndexOptions()
+    {
+        var sql = GenerateCreateIndexSql<VectorIndexOptionsContext, IndexingItem>();
+
+        sql.ShouldBe(
+            """
+            CREATE INDEX indexing_items_idx ON indexing_items USING paradedb (id, description, embedding_cosine vector_cosine_ops) WITH (key_field = 'id', centroid_ratio = 0.05, training_samples_per_centroid = 64, cluster_replication = 2);
+
+            """
+        );
+    }
+
+    private sealed class CentroidRatioIndexContext(
+        DbContextOptions<CentroidRatioIndexContext> options
+    ) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<IndexingItem>(entity =>
+            {
+                entity.ToTable("indexing_items");
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Description).HasColumnName("description");
+
+                entity
+                    .HasParadeDbIndex("indexing_items_idx", e => e.Id)
+                    .HasField(e => e.Description)
+                    .HasCentroidRatio(0.5);
+            });
+        }
+    }
+
+    [Test]
+    public void ParadeDbIndex_WithSingleVectorIndexOption()
+    {
+        var sql = GenerateCreateIndexSql<CentroidRatioIndexContext, IndexingItem>();
+
+        sql.ShouldBe(
+            """
+            CREATE INDEX indexing_items_idx ON indexing_items USING paradedb (id, description) WITH (key_field = 'id', centroid_ratio = 0.5);
+
+            """
+        );
+    }
+
     private static string GenerateCreateIndexSql<TContext, TEntity>()
         where TContext : DbContext
     {


### PR DESCRIPTION
Exposes pg_search 0.25.0+ vector index build options (`centroid_ratio`, `training_samples_per_centroid`, `cluster_replication`) on `ParadeDbIndexBuilder`, so they can be set without raw SQL. They flow through the model annotations into migration-generated `WITH (...)` DDL, alongside `key_field` and `search_tokenizer`.

```csharp
entity
    .HasParadeDbIndex("search_idx", e => e.Id)
    .HasField(e => e.Embedding, VectorMetric.Cosine)
    .HasCentroidRatio(0.05)
    .HasTrainingSamplesPerCentroid(64)
    .HasClusterReplication(2);
// ... WITH (key_field = 'id', centroid_ratio = 0.05, training_samples_per_centroid = 64, cluster_replication = 2)
```