### PR TITLE
fix(examples): use ParadeDB vector search in the RAG example

### DIFF
--- a/examples/Rag/Program.cs
+++ b/examples/Rag/Program.cs
@@ -4,8 +4,8 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using ParadeDB.EntityFrameworkCore.Extensions;
+using HybridRrf.Data;
 using Rag;
-using Rag.Data;
 using Shared;
 
 var config = new ConfigurationBuilder().AddUserSecrets<ProductResult>().Build();
@@ -36,17 +36,43 @@ await ExampleSetup.SetupMockItemsAsync(dbContext);
 var count = await dbContext.MockItems.CountAsync();
 Console.WriteLine($"Loaded {count} products");
 
-await Rag(dbContext, "What running shoes do you have?", openRouterApiKey, model);
-await Rag(dbContext, "I need comfortable shoes for everyday use", openRouterApiKey, model);
-await Rag(dbContext, "Do you have any wireless audio products?", openRouterApiKey, model);
+await Rag(
+    dbContext,
+    "What running shoes do you have?",
+    "Sleek running shoes",
+    openRouterApiKey,
+    model
+);
+await Rag(
+    dbContext,
+    "I need comfortable shoes for everyday use",
+    "Comfortable slippers",
+    openRouterApiKey,
+    model
+);
+await Rag(
+    dbContext,
+    "Do you have any wireless audio products?",
+    "Innovative wireless earbuds",
+    openRouterApiKey,
+    model
+);
 
 Console.WriteLine();
 Console.WriteLine(new string('=', 60));
 Console.WriteLine("Done!");
 return;
 
-static async Task<List<ProductResult>> Retrieve(AppDbContext db, string query, int topK = 5)
+static async Task<List<ProductResult>> Retrieve(
+    AppDbContext db,
+    string query,
+    float[] queryEmbedding,
+    int topK = 5
+)
 {
+    // The @@@ predicate (Parse) narrows to keyword matches and activates the
+    // ParadeDB index scan; ordering by CosineDistance then ranks those matches
+    // semantically. One index serves both halves.
     return await db
         .MockItems.Where(x => EF.Functions.Parse(x.Description, query, lenient: true))
         .Select(x => new ProductResult
@@ -57,9 +83,9 @@ static async Task<List<ProductResult>> Retrieve(AppDbContext db, string query, i
             Rating = x.Rating,
             InStock = x.InStock,
             Metadata = x.Metadata,
-            Score = EF.Functions.Score(x.Id),
+            Distance = EF.Functions.CosineDistance(x.Embedding, queryEmbedding),
         })
-        .OrderByDescending(x => x.Score)
+        .OrderBy(x => x.Distance)
         .Take(topK)
         .ToListAsync();
 }
@@ -150,17 +176,30 @@ static async Task<string> Generate(string query, string context, string? apiKey,
     }
 }
 
-static async Task Rag(AppDbContext db, string query, string? apiKey, string model)
+static async Task Rag(
+    AppDbContext db,
+    string query,
+    string seedDescription,
+    string? apiKey,
+    string model
+)
 {
     Console.WriteLine($"\n{new string('=', 60)}");
     Console.WriteLine($"Question: {query}");
     Console.WriteLine(new string('=', 60));
 
-    var items = await Retrieve(db, query);
+    // The mock_items table ships with a pre-populated embedding column; use the
+    // embedding of a known item as the semantic query vector
+    var queryEmbedding = await db
+        .MockItems.Where(x => x.Description == seedDescription)
+        .Select(x => x.Embedding!)
+        .FirstAsync();
+
+    var items = await Retrieve(db, query, queryEmbedding);
 
     Console.WriteLine($"\nRetrieved {items.Count} products:");
     foreach (var item in items)
-        Console.WriteLine($"  • {item.Description} (score: {item.Score:F2})");
+        Console.WriteLine($"  • {item.Description} (distance: {item.Distance:F4})");
 
     var context = FormatContext(items);
 
@@ -181,6 +220,6 @@ namespace Rag
         public int Rating { get; set; }
         public bool InStock { get; set; }
         public JsonDocument? Metadata { get; set; }
-        public float Score { get; set; }
+        public double Distance { get; set; }
     }
 }

--- a/examples/Rag/Program.cs
+++ b/examples/Rag/Program.cs
@@ -70,9 +70,6 @@ static async Task<List<ProductResult>> Retrieve(
     int topK = 5
 )
 {
-    // The @@@ predicate (Parse) narrows to keyword matches and activates the
-    // ParadeDB index scan; ordering by CosineDistance then ranks those matches
-    // semantically. One index serves both halves.
     return await db
         .MockItems.Where(x => EF.Functions.Parse(x.Description, query, lenient: true))
         .Select(x => new ProductResult

--- a/examples/Rag/Program.cs
+++ b/examples/Rag/Program.cs
@@ -1,10 +1,10 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using HybridRrf.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using ParadeDB.EntityFrameworkCore.Extensions;
-using HybridRrf.Data;
 using Rag;
 using Shared;
 

--- a/examples/Shared/AppDbContexts.cs
+++ b/examples/Shared/AppDbContexts.cs
@@ -70,15 +70,8 @@ namespace Quickstart.Data
     }
 }
 
-namespace Rag.Data
-{
-    public class AppDbContext : Shared.MockItemsDbContext<AppDbContext, Shared.MockItem>
-    {
-        public AppDbContext(DbContextOptions<AppDbContext> options)
-            : base(options) { }
-    }
-}
-
+// The Rag and VectorSearch examples reuse HybridRrf.Data.AppDbContext, since
+// they also query the embedding column.
 namespace HybridRrf.Data
 {
     public class AppDbContext : Shared.MockItemsDbContext<AppDbContext, MockItemWithEmbedding>


### PR DESCRIPTION
The recent vector search work put the vector column inside the ParadeDB index in every ORM, but some examples still query it the old way. This fixes the ones in this repo. Companion PRs are open in the other affected repos; sqlalchemy needed no change.

## The problem

For the ParadeDB index to serve a vector query, three things are required together: a `@@@` predicate, a distance operator matching the index opclass metric, and a `LIMIT`. Drop the `@@@` predicate and the query still returns correct rows, so nothing fails loudly — it just silently stops using the index and becomes a sequential scan plus a sort. That is exactly the vanilla pgvector behavior these examples are meant to show you how to avoid.

## Verification

Measured with `EXPLAIN` against ParadeDB 0.25.0. Before:

```text
Limit
  ->  Sort
        Sort Key: ((embedding <=> '[...]'::vector))
        ->  Seq Scan on mock_items
```

After:

```text
Limit
  ->  Custom Scan (ParadeDB Base Scan) on mock_items
        Table: mock_items
        Index: search_idx
        Exec Method: TopKScanExecState
        Scores: false
           TopK Order By: embedding <=> vector asc
           TopK Limit: 20
        Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
```

Every changed example was run end to end against a live ParadeDB container and produces sensible rankings.

## What changed here

**`examples/Rag/Program.cs`** — retrieval was BM25-only, with no vector step at all, even though the hybrid example does it correctly. Now uses the same shape as the rails and drizzle RAG examples: `Parse` narrows to keyword matches and activates the index scan, `CosineDistance` orders those matches semantically. The query vector comes from a seed item embedding, the same trick `HybridRrf` and `VectorSearch` already use.

**`examples/Shared/AppDbContexts.cs`** — `Rag.Data.AppDbContext` mapped `Shared.MockItem`, which has no `Embedding` property, so RAG could not reach the vector column at all. The example now reuses `HybridRrf.Data.AppDbContext`, as `VectorSearch` already does, and the unused context is removed.

Heads-up on verification: I have no .NET SDK available locally, so unlike the other repos in this set I could not build or run this one. The SQL shape is verified (see the EXPLAIN above, measured via the equivalent query), but please give the C# a closer look than usual — CI is the first real compile.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4
