### PR TITLE
docs: spell out Retrieval-Augmented Generation and name pg_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/)
 | .NET       | 8.0+                                                               |
 | EF Core    | 8.0+                                                               |
 | ParadeDB   | 0.25.0+                                                            |
-| PostgreSQL | 15+ (with ParadeDB extension)                                      |
+| PostgreSQL | 15+ (with the ParadeDB pg_search extension)                        |
 | pgvector   | Required for vector search (included in the ParadeDB Docker image) |
 
 ## Examples
@@ -54,7 +54,7 @@ The official [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/)
 - [Vector Search](examples/VectorSearch/Program.cs)
 - [Faceted Search](examples/FacetedSearch/Program.cs)
 - [Hybrid Search (RRF)](examples/HybridRrf/Program.cs)
-- [RAG](examples/Rag/Program.cs)
+- [Retrieval-Augmented Generation (RAG)](examples/Rag/Program.cs)
 - [Autocomplete](examples/Autocomplete/Program.cs)
 - [More Like This](examples/MoreLikeThis/Program.cs)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ Requires the `pgvector` extension, which is included in the ParadeDB Docker imag
 dotnet run --project examples/Examples.csproj -p:Example=HybridRrf
 ```
 
-## RAG (`Rag/Program.cs`)
+## Retrieval-Augmented Generation (RAG) (`Rag/Program.cs`)
 
 A small question-answering flow. Retrieves relevant context with ParadeDB, then sends it to an LLM so answers are grounded in your own data.
 


### PR DESCRIPTION
- Expands **RAG** to **Retrieval-Augmented Generation (RAG)** in the README example list and the `examples/README.md` section heading, matching how **Hybrid Search (RRF)** already spells out its acronym.
- Names the extension explicitly in the PostgreSQL requirements row: `15+ (with the ParadeDB pg_search extension)`.

Applied identically across all five ORM integrations. Table column widths were re-flowed by prettier. markdownlint, prettier and codespell pass.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4