### PR TITLE
chore: align repo hygiene config across ORM integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,10 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Editors
+.vscode/
+*.swo
+
+# Agent tooling
+.claude/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,9 @@ repos:
       - id: check-symlinks
       - id: check-yaml
       - id: check-json
+      - id: check-ast
+      - id: check-docstring-first
+      - id: debug-statements
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
       - id: check-vcs-permalinks
@@ -34,6 +37,7 @@ repos:
     hooks:
       - id: codespell
         args: ["--config", ".codespellrc", "--check-filenames"]
+        exclude: ^assets/
 
   - repo: local
     hooks:

--- a/src/ParadeDB.EntityFrameworkCore.csproj
+++ b/src/ParadeDB.EntityFrameworkCore.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <PackageId>ParadeDB.EntityFrameworkCore</PackageId>
     <Title>ParadeDB Entity Framework Core Integration</Title>
-    <Description>Official Entity Framework Core integration for ParadeDB search on PostgreSQL via Npgsql.</Description>
+    <Description>Official ParadeDB integration for Entity Framework Core</Description>
     <PackageTags>BM25;EntityFrameworkCore;EFCore;Faceted Search;Facets;Full Text Search;Hybrid Search;ParadeDB;Postgres;PostgreSQL;Search;Text Search</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
Follow-up to the standardization sweep, covering the config that was still divergent. Each change matches what the repo actually **contains**, rather than just matching the other repos.

## `.gitignore`

All five now ignore the same editor, OS, environment and agent files. sqlalchemy additionally picked up the Python build and tool-cache artifacts its own CI produces (`build/`, `dist/`, `*.egg-info/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `coverage.xml`) — it was ignoring only 5 paths where django ignores 40.

## pre-commit hooks

- Dropped `requirements-txt-fixer` everywhere — **no repo has a `requirements.txt`**
- Dropped `check-toml` from drizzle, which has no TOML files
- Added `check-ast`, `check-docstring-first`, `debug-statements` to rails and efcore, which both ship Python scripts under `scripts/` that were going unchecked
- Gave the `codespell` hook an `exclude` mirroring each `.codespellrc` skip list

**That last one fixes a live bug.** codespell only honors `skip` when it walks directories itself; pre-commit passes explicit filenames, which bypasses it. So the skip list applied in CI but not locally. drizzle's hook failed for anyone running it, on a false positive in `pnpm-lock.yaml`:

```
codespell................................................................Failed
  pnpm-lock.yaml:1048: Nd ==> And, 2nd
```

Verified: `prek run --all-files` now passes clean in django, sqlalchemy and drizzle (rails and efcore need Ruby 4.0 / .NET, checked separately below).

## Other

- `FUNDING.yml`: sqlalchemy still carried GitHub's full commented-out template
- Package descriptions unified to `Official ParadeDB integration for X`. These are user-visible on PyPI, npm, RubyGems and NuGet, and read four different ways.

## Verification

- django: full test suite (322) passes; `prek run --all-files` clean
- sqlalchemy: `prek run --all-files` clean
- drizzle: `pnpm typecheck` passes, `package.json` parses, `prek` clean
- rails: `rubocop --lint` clean over 49 files (Ruby 3.4 container)
- efcore: `dotnet build -c Release` clean, 0 warnings (.NET 10 container)

## Repo-specific

- `<Description>` shortened to match the other four

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4