### PR TITLE
fix: give each ORM integration its own ParadeDB container name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,6 @@ Prefer `dotnet test` over `dotnet build` when verifying changes.
 
 Some tests require newer pg_search versions and are skipped automatically if the feature is not available.
 
-The tests provision their own database with Testcontainers. The examples instead use `scripts/run_paradedb.sh`, whose default container is `efcore-paradedb` on port `5432`. Each ParadeDB ORM integration uses its own container name, so a container from another repo is never reused by mistake. They all bind port `5432`, so stop one before starting another.
 
 ### Linting and Formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ Prefer `dotnet test` over `dotnet build` when verifying changes.
 
 Some tests require newer pg_search versions and are skipped automatically if the feature is not available.
 
+The tests provision their own database with Testcontainers. The examples instead use `scripts/run_paradedb.sh`, whose default container is `efcore-paradedb` on port `5432`. Each ParadeDB ORM integration uses its own container name, so a container from another repo is never reused by mistake. They all bind port `5432`, so stop one before starting another.
+
 ### Linting and Formatting
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,6 @@ Prefer `dotnet test` over `dotnet build` when verifying changes.
 
 Some tests require newer pg_search versions and are skipped automatically if the feature is not available.
 
-
 ### Linting and Formatting
 
 ```bash

--- a/scripts/run_paradedb.sh
+++ b/scripts/run_paradedb.sh
@@ -14,7 +14,7 @@ fi
 PARADEDB_VERSION="${PARADEDB_VERSION:-0.25.0}"
 PARADEDB_POSTGRES_VERSION="${PARADEDB_POSTGRES_VERSION:-18}"
 IMAGE="${PARADEDB_IMAGE:-paradedb/paradedb:${PARADEDB_VERSION}-pg${PARADEDB_POSTGRES_VERSION}}"
-CONTAINER_NAME="${PARADEDB_CONTAINER_NAME:-paradedb-integration}"
+CONTAINER_NAME="${PARADEDB_CONTAINER_NAME:-efcore-paradedb}"
 
 # Allow overriding connection details via env vars
 PORT="${PARADEDB_PORT:-5432}"
@@ -23,6 +23,7 @@ PASSWORD="${PARADEDB_PASSWORD:-postgres}"
 DB="${PARADEDB_DB:-postgres}"
 
 DATABASE_URL="${DATABASE_URL:-postgresql://${USER}:${PASSWORD}@localhost:${PORT}/${DB}}"
+export DATABASE_URL
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required to run ParadeDB" >&2


### PR DESCRIPTION
## The problem

django, rails and efcore all defaulted to the **same container name** — `paradedb-integration`. Working on two of them locally meant the second repo silently reused the first's container, with the first repo's schema and data. Nothing errors; you just get wrong results.

## The fix

Each repo names its container after itself:

| Repo | Container | Port |
|---|---|---|
| django | `django-paradedb` | 5432 |
| sqlalchemy | `sqlalchemy-paradedb` | 5432 |
| drizzle | `drizzle-paradedb` | 5432 |
| rails | `rails-paradedb` | 5432 |
| efcore | `efcore-paradedb` | 5432 |

All five keep binding `5432`, so starting a second while another runs now fails loudly on the port rather than quietly attaching to the wrong database. sqlalchemy moves from `5443` to `5432` to match. Both values remain overridable via `PARADEDB_CONTAINER_NAME` and `PARADEDB_PORT`, and `CONTRIBUTING.md` documents the pair in every repo.

## A latent bug this surfaced

efcore's `scripts/run_paradedb.sh` set `DATABASE_URL` but **never exported it**, unlike django, sqlalchemy and rails. Child processes never saw it, so the examples fell through to the `PGHOST`/`PGPORT` defaults in `ExampleSetup.ConnectionString` and reached the database only because those defaults happen to be `localhost:5432`. Correct now regardless of how the port is configured.

## Verification

- django: full suite (322 tests) passes against `django-paradedb`
- efcore: Quickstart example runs against `efcore-paradedb` via the newly exported `DATABASE_URL` (.NET 10 container)
- efcore's own tests are unaffected — they provision their database with Testcontainers
- shellcheck, beautysh, prettier, markdownlint and codespell pass

Note for reviewers: anyone with an existing `paradedb-integration` container will get a fresh one on first run. Harmless for throwaway dev data, but worth knowing.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4