### PR TITLE
test: add a packaging smoke test to every ORM integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,6 @@ jobs:
 
       - name: Check API coverage
         run: uv run --with json5 scripts/check_api_coverage.py
+
+      - name: Package install smoke test
+        run: bash scripts/smoke_package_install.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ Run these before opening a PR if your change touches SQL wrappers, API constants
 
 ```bash
 uv run --with json5 scripts/check_api_coverage.py
+bash scripts/smoke_package_install.sh
 ```
 
 ### Pull Request Workflow

--- a/scripts/smoke_package_install.sh
+++ b/scripts/smoke_package_install.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# smoke_package_install.sh
+#
+# Packs the NuGet package, restores it into a throwaway project from a local
+# feed, and compiles against the public API. This catches packaging problems the
+# test suite cannot see, because the tests reference the project directly while
+# consumers get only what the .nupkg actually ships.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+PROJECT="src/ParadeDB.EntityFrameworkCore.csproj"
+PACKAGE_ID="ParadeDB.EntityFrameworkCore"
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/efcore-paradedb-smoke.XXXXXX")"
+cleanup() {
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+FEED_DIR="${WORK_DIR}/feed"
+APP_DIR="${WORK_DIR}/app"
+
+echo "Packing ${PACKAGE_ID}..."
+dotnet pack "${PROJECT}" --configuration Release --output "${FEED_DIR}" >/dev/null
+
+NUPKG="$(find "${FEED_DIR}" -maxdepth 1 -name "${PACKAGE_ID}.*.nupkg" ! -name '*.symbols.nupkg' | head -1)"
+if [[ -z "${NUPKG}" ]]; then
+  echo "❌ dotnet pack produced no .nupkg" >&2
+  exit 1
+fi
+
+VERSION="$(basename "${NUPKG}")"
+VERSION="${VERSION#"${PACKAGE_ID}."}"
+VERSION="${VERSION%.nupkg}"
+
+mkdir -p "${APP_DIR}"
+cd "${APP_DIR}"
+
+dotnet new console --output . >/dev/null
+
+# Restore the packed package from the local feed only; its dependencies still
+# come from nuget.org.
+cat > nuget.config <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="paradedb-smoke" value="${FEED_DIR}" />
+  </packageSources>
+</configuration>
+XML
+
+cat > Program.cs <<'CSHARP'
+using System.Reflection;
+using ParadeDB.EntityFrameworkCore.Extensions;
+
+// Referencing these at compile time proves the public API shipped in the
+// package; reflecting over them proves the assembly loads at runtime.
+var type = typeof(ParadeDbFunctionsExtensions);
+var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
+
+foreach (var name in new[] { "MatchAll", "Score", "Parse" })
+{
+    if (!methods.Any(m => m.Name == name))
+    {
+        Console.Error.WriteLine($"Expected public static {type.Name}.{name} in the packed assembly");
+        return 1;
+    }
+}
+
+Console.WriteLine($"Package smoke install passed for {type.Assembly.GetName().Name}");
+return 0;
+CSHARP
+
+dotnet add package "${PACKAGE_ID}" --version "${VERSION}" >/dev/null
+dotnet run --configuration Release
+
+echo "✅ Package smoke install passed for ${PACKAGE_ID} ${VERSION}"


### PR DESCRIPTION
drizzle and efcore had **no packaging check at all**. django and sqlalchemy had `smoke_wheel_install.sh`, rails had `smoke_gem_install.sh`; all three are now `scripts/smoke_package_install.sh`, so the file has the same name everywhere.

## Why this matters more than it sounds

A packaging smoke test catches a class of bug the test suite structurally **cannot**: the tests import from the source tree, while consumers get only what the published artifact actually contains.

Concretely, django and sqlalchemy force-include `api.json5` into the wheel and load it at import time to define every API constant. A regression there would ship a package that fails on import for every user, while CI stayed entirely green.

## What each script does

Each builds the real artifact, installs it into a throwaway project, and exercises the public API **from the installed copy**:

| Repo | Approach |
|---|---|
| django, sqlalchemy | build the wheel → install into a fresh venv → compile a query, assert `&&&` |
| drizzle | `pnpm build` → `npm pack` → assert `dist/index.js` and `dist/index.d.ts` are in the tarball → install into a scratch project → assert `PgDialect` renders `&&&` |
| rails | `gem build` → install into an isolated `GEM_HOME` → assert the Arel node is a ParadeDB match infix operation |
| efcore | `dotnet pack` → restore from a local feed into a scratch console project → assert `MatchAll`, `Score`, `Parse` are public statics on the packed assembly |

All five run in CI as **Package install smoke test**, and are documented under *API and Packaging Consistency Checks* — drizzle and efcore previously documented no packaging step.

## Verification

Every script exits 0 as-is:

```
django      ✅ Package smoke install passed for django-paradedb 0.12.0
sqlalchemy  ✅ Package smoke install passed for sqlalchemy-paradedb 0.10.0
drizzle     ✅ Package smoke install passed for @paradedb/drizzle-paradedb@0.4.0
rails       ✅ Package smoke install passed for rails-paradedb 0.11.0
efcore      ✅ Package smoke install passed for ParadeDB.EntityFrameworkCore 1.0.0
```

And they were **negative-tested**, so they aren't inert:

- breaking drizzle's `files` so `dist` isn't published → exit 1, `❌ package/dist/index.d.ts missing from the packed tarball`
- asking efcore for a method that doesn't exist → exit 1, `Expected public static ParadeDbFunctionsExtensions.ThisMethodDoesNotExist in the packed assembly`

rails ran in a Ruby 3.4 container and efcore in a .NET 10 container, since this machine has neither toolchain. shellcheck, beautysh, prettier, markdownlint and codespell all pass.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4