### PR TITLE
fix: remove pdb.alias from apiignore, it is already wrapped

### DIFF
--- a/apiignore.json5
+++ b/apiignore.json5
@@ -275,7 +275,6 @@
   ],
 
   "types": [
-    "pdb.alias",
     "pdb.proximityclause",
     "pdb.query"
   ]


### PR DESCRIPTION
`pdb.alias` appeared in **both** manifests at once: wrapped as `PDB_TYPE_TOKENIZER_ALIAS` in `api.json5`, while also listed in `apiignore.json5` as a symbol the repo *"intentionally does not wrap"*.

Those two statements contradict each other. The wrap is correct, so the stale ignore entry is removed.

Part of a set correcting `api.json5` / `apiignore.json5` bookkeeping across the ORM integrations. The companion rails PR is larger: it was under-declaring four symbols (`##>`, `pdb.regex_phrase`, `pdb.prox_regex`, `pdb.prox_array`) that it already implements and tests.

**No behavior changes and no new API surface** — this only makes the manifests describe the code that already exists.

## Verification

- `check_api_coverage.py` passes
- No symbol appears in both manifests, in any of the five repos
- prettier and codespell pass

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4